### PR TITLE
[SCV-21] Update Pagination

### DIFF
--- a/docs/WFS3core+STAC.yaml
+++ b/docs/WFS3core+STAC.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.1
 info:
   title: The SpatioTemporal Asset Catalog API
-  version: 0.8.0
+  version: 0.9.0
   license:
     name: Apache License 2.0
     url: 'http://www.apache.org/licenses/LICENSE-2.0'
@@ -10,7 +10,8 @@ info:
     specification. Any service that implements this endpoint to allow search of
     spatiotemporal assets can be considered a STAC API. The endpoint is also
     available as an OpenAPI fragment that can be integrated with other OpenAPI
-    definitions, and is designed to slot seamlessly into a WFS 3 API definition.
+    definitions, and is designed to slot seamlessly into a OGC API - Features
+    definition.
   contact:
     name: STAC Specification
     url: 'http://stacspec.org'
@@ -20,7 +21,9 @@ tags:
   - name: Data
     description: access to data (features)
   - name: STAC
-    description: Extension to WFS3 Core to support STAC metadata model and search API
+    description: >-
+      Extension to OGC API - Features to support STAC metadata model and search
+      API
 paths:
   /:
     get:
@@ -28,8 +31,13 @@ paths:
         - Capabilities
       summary: landing page
       description: |-
+        Returns the root STAC Catalog or STAC Collection that is the entry point
+        for users to browse with STAC Browser or for search engines to crawl.
+        This can either return a single STAC Collection or more commonly a STAC
+        catalog.
+
         The landing page provides links to the API definition, the conformance
-        statements and to the feature collections in this dataset.
+        statements, the collections and sub-catalogs.
       operationId: getLandingPage
       responses:
         '200':
@@ -42,7 +50,7 @@ paths:
         - Capabilities
       summary: information about specifications that this API conforms to
       description: |-
-        A list of all conformance classes specified in a standard that the 
+        A list of all conformance classes specified in a standard that the
         server conforms to.
       operationId: getConformanceDeclaration
       responses:
@@ -125,34 +133,20 @@ paths:
           $ref: '#/components/responses/NotFound'
         '500':
           $ref: '#/components/responses/ServerError'
-  /stac:
-    get:
-      summary: Return the root catalog or collection.
-      description: >-
-        Returns the root STAC Catalog or STAC Collection that is the entry point
-        for users to browse with STAC Browser or for search engines to crawl.
-        This can either return a single STAC Collection or more commonly a STAC
-        catalog that usually lists sub-catalogs of STAC Collections, i.e. a
-        simple catalog that lists all collections available through the API.
-      tags:
-        - STAC
-      responses:
-        '200':
-          description: A catalog JSON definition. Used as an entry point for a crawler.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/catalogDefinition'
-  /stac/search:
+  /search:
     get:
       summary: Search STAC items with simple filtering.
-      description: >-
+      description: |-
         Retrieve Items matching filters. Intended as a shorthand API for simple
         queries.
 
+        This method is optional, but you MUST implement `POST /search` if you
+        want to implement this method.
 
-        This method is optional, but you MUST implement `POST /stac/search` if
-        you want to implement this method.
+        If this endpoint is implemented on a server, it is required to add a
+        link referring to this endpoint with `rel` set to `search` to the
+        `links` array in `GET /`. As `GET` is the default method, the `method`
+        may not be set explicitly in the link.
       operationId: getSearchSTAC
       tags:
         - STAC
@@ -160,9 +154,8 @@ paths:
         - $ref: '#/components/parameters/bbox'
         - $ref: '#/components/parameters/datetime'
         - $ref: '#/components/parameters/limit'
-        - $ref: '#/components/parameters/page'
         - $ref: '#/components/parameters/ids'
-        - $ref: '#/components/parameters/collections'
+        - $ref: '#/components/parameters/collectionsArray'
       responses:
         '200':
           description: A feature collection.
@@ -184,15 +177,14 @@ paths:
                 type: string
     post:
       summary: Search STAC items with full-featured filtering.
-      description: >-
+      description: |-
         retrieve items matching filters. Intended as the standard, full-featured
         query API.
 
-
-        This method is mandatory to implement if `GET /stac/search` is
-        implemented. If this endpoint is implemented on a server, it is required
-        to add a link with `rel` set to `search` to the `links` array in `GET
-        /stac` that refers to this endpoint.
+        This method is mandatory to implement if `GET /search` is implemented.
+        If this endpoint is implemented on a server, it is required to add a
+        link referring to this endpoint with `rel` set to `search` and `method`
+        set to `POST` to the `links` array in `GET /`.
       operationId: postSearchSTAC
       tags:
         - STAC
@@ -230,53 +222,64 @@ components:
         selected.
 
         The bounding box is provided as four or six numbers, depending on
-        whether the
 
-        coordinate reference system includes a vertical axis (elevation or
-        depth):
+        whether the coordinate reference system includes a vertical axis (height
+
+        or depth):
 
 
         * Lower left corner, coordinate axis 1
 
         * Lower left corner, coordinate axis 2
 
-        * Lower left corner, coordinate axis 3 (optional)
+        * Minimum value, coordinate axis 3 (optional)
 
         * Upper right corner, coordinate axis 1
 
         * Upper right corner, coordinate axis 2
 
-        * Upper right corner, coordinate axis 3 (optional)
+        * Maximum value, coordinate axis 3 (optional)
 
 
         The coordinate reference system of the values is WGS 84
-        longitude/latitude
 
-        (http://www.opengis.net/def/crs/OGC/1.3/CRS84) unless a different
-        coordinate
+        longitude/latitude (http://www.opengis.net/def/crs/OGC/1.3/CRS84) unless
 
-        reference system is specified in the parameter `bbox-crs`.
+        a different coordinate reference system is specified in the parameter
+
+        `bbox-crs`.
 
 
         For WGS 84 longitude/latitude the values are in most cases the sequence
-        of
 
-        minimum longitude, minimum latitude, maximum longitude and maximum
-        latitude.
+        of minimum longitude, minimum latitude, maximum longitude and maximum
 
-        However, in cases where the box spans the antimeridian the first value
+        latitude. However, in cases where the box spans the antimeridian the
 
-        (west-most box edge) is larger than the third value (east-most box
-        edge).
+        first value (west-most box edge) is larger than the third value
+
+        (east-most box edge).
+
+
+        If the vertical axis is included, the third and the sixth number are
+
+        the bottom and the top of the 3-dimensional bounding box.
 
 
         If a feature has multiple spatial geometry properties, it is the
-        decision of the
 
-        server whether only a single spatial geometry property is used to
-        determine
+        decision of the server whether only a single spatial geometry property
 
-        the extent or all relevant geometries.
+        is used to determine the extent or all relevant geometries.
+
+
+        Example: The bounding box of the New Zealand Exclusive Economic Zone in
+
+        WGS 84 (from 160.6°E to 170°W and from 55.95°S to 25.89°S) would be
+
+        represented in JSON as `[160.6, -55.95, -170, -25.89]` and in a query as
+
+        `bbox=160.6,-55.95,-170,-25.89`.
       required: false
       schema:
         type: array
@@ -359,55 +362,25 @@ components:
         default: 10
       style: form
       explode: false
-    page:
-      name: page
-      in: query
-      description: |
-        The optional page parameter returns the specified page of results
-        (with each page having size=limit).
-
-        * Minimum = 1
-        * Default = 1
-      required: false
-      schema:
-        type: integer
-        minimum: 1
-        default: 1
-      style: form
-      explode: false
     ids:
       name: ids
       in: query
-      description: >
-        The optional ids parameter returns a FeatureCollection of all matching
-        ids.
-
-        If provided all other parameters that further restrict the number of
-        search results (except `page` and `limit`) will be ignored.
+      description: |-
+        Array of Item ids to return. All other filter parameters that further
+        restrict the number of search results are ignored
       required: false
       schema:
-        type: array
-        minItems: 1
-        items:
-          type: string
+        $ref: '#/components/schemas/ids'
       explode: false
-    collections:
+    collectionsArray:
       name: collections
       in: query
-      description: >
-        The collections search parameter is a list of of collection IDs for
-        Items to match.
-
-        Only items that are included in one of these collections will be
-        returned, otherwise
-
-        all collections will be searched.
+      description: |
+        Array of Collection IDs to include in the search for items.
+        Only Items in one of the provided Collections will be searched
       required: false
       schema:
-        type: array
-        minItems: 1
-        items:
-          type: string
+        $ref: '#/components/schemas/collectionsArray'
       explode: false
   schemas:
     collection:
@@ -415,6 +388,10 @@ components:
       required:
         - id
         - links
+        - stac_version
+        - description
+        - license
+        - extent
       properties:
         id:
           description: 'identifier of the collection used, for example, in URIs'
@@ -428,6 +405,7 @@ components:
           description: a description of the features in the collection
           type: string
           example: An address.
+          $ref: '#/components/schemas/description'
         links:
           type: array
           items:
@@ -456,6 +434,162 @@ components:
           example:
             - 'http://www.opengis.net/def/crs/OGC/1.3/CRS84'
             - 'http://www.opengis.net/def/crs/EPSG/0/4326'
+        stac_version:
+          $ref: '#/components/schemas/stac_version'
+        stac_extensions:
+          $ref: '#/components/schemas/stac_extensions'
+        keywords:
+          type: array
+          description: List of keywords describing the collection.
+          items:
+            type: string
+        license:
+          $ref: '#/components/schemas/license'
+        providers:
+          $ref: '#/components/schemas/providers'
+        summaries:
+          description: |-
+            Summaries are either a unique set of all available values *or*
+            statistics. Statistics by default only specify the range (minimum
+            and maximum values), but can optionally be accompanied by additional
+            statistical values. The range can specify the potential range of
+            values, but it is recommended to be as precise as possible. The set
+            of values must contain at least one element and it is strongly
+            recommended to list all values. It is recommended to list as many
+            properties as reasonable so that consumers get a full overview of
+            the Collection. Properties that are covered by the Collection
+            specification (e.g. `providers` and `license`) may not be repeated
+            in the summaries.
+          type: object
+          additionalProperties:
+            oneOf:
+              - type: array
+                title: Set of values
+                items:
+                  description: A value of any type.
+              - type: object
+                title: Statistics
+                description: |-
+                  By default, only ranges with a minimum and a maximum value can
+                  be specified. Ranges can be specified for ordinal values only,
+                  which means they need to have a rank order. Therefore, ranges
+                  can only be specified for numbers and some special types of
+                  strings. Examples: grades (A to F), dates or times.
+                  Implementors are free to add other derived statistical values
+                  to the object, for example `mean` or `stddev`.
+                required:
+                  - min
+                  - max
+                properties:
+                  min:
+                    anyOf:
+                      - type: string
+                      - type: number
+                  max:
+                    anyOf:
+                      - type: string
+                      - type: number
+      example:
+        stac_version: 0.9.0
+        stac_extensions: []
+        id: Sentinel-2
+        title: 'Sentinel-2 MSI: MultiSpectral Instrument, Level-1C'
+        description: |
+          Sentinel-2 is a wide-swath, high-resolution, multi-spectral
+          imaging mission...
+        license: proprietary
+        keywords:
+          - copernicus
+          - esa
+          - eu
+          - msi
+          - radiance
+          - sentinel
+        providers:
+          - name: ESA
+            roles:
+              - producer
+              - licensor
+            url: 'https://sentinel.esa.int/web/sentinel/user-guides/sentinel-2-msi'
+        extent:
+          spatial:
+            bbox:
+              - - -180
+                - -56
+                - 180
+                - 83
+          temporal:
+            interval:
+              - - '2015-06-23T00:00:00Z'
+                - '2019-07-10T13:44:56Z'
+        summaries:
+          datetime:
+            min: '2015-06-23T00:00:00Z'
+            max: '2019-07-10T13:44:56Z'
+          'sci:citation':
+            - 'Copernicus Sentinel data [Year]'
+          'eo:gsd':
+            - 10
+            - 30
+            - 60
+          platform:
+            - sentinel-2a
+            - sentinel-2b
+          constellation:
+            - sentinel-2
+          instruments:
+            - msi
+          'view:off_nadir':
+            min: 0
+            max: 100
+          'view:sun_elevation':
+            min: 6.78
+            max: 89.9
+          'eo:bands':
+            - - name: B1
+                common_name: coastal
+                center_wavelength: 4.439
+              - name: B2
+                common_name: blue
+                center_wavelength: 4.966
+              - name: B3
+                common_name: green
+                center_wavelength: 5.6
+              - name: B4
+                common_name: red
+                center_wavelength: 6.645
+              - name: B5
+                center_wavelength: 7.039
+              - name: B6
+                center_wavelength: 7.402
+              - name: B7
+                center_wavelength: 7.825
+              - name: B8
+                common_name: nir
+                center_wavelength: 8.351
+              - name: B8A
+                center_wavelength: 8.648
+              - name: B9
+                center_wavelength: 9.45
+              - name: B10
+                center_wavelength: 1.3735
+              - name: B11
+                common_name: swir16
+                center_wavelength: 1.6137
+              - name: B12
+                common_name: swir22
+                center_wavelength: 2.2024
+        links:
+          - rel: self
+            href: 'http://cool-sat.com/collections/Sentinel-2'
+          - rel: root
+            href: 'http://cool-sat.com/collections'
+          - rel: license
+            href: >-
+              https://scihub.copernicus.eu/twiki/pub/SciHubWebPortal/TermsConditions/Sentinel_Data_Terms_and_Conditions.pdf
+            title: >-
+              Legal notice on the use of Copernicus Sentinel Data and Service
+              Information
     collections:
       type: object
       required:
@@ -484,13 +618,13 @@ components:
       description: >-
         Information about the exception: an error code plus an optional
         description.
+      required:
+        - code
       properties:
         code:
           type: string
         description:
           type: string
-      required:
-        - code
     extent:
       type: object
       description: >-
@@ -503,6 +637,7 @@ components:
         extents, for example, thermal or pressure ranges.
       properties:
         spatial:
+          description: The spatial extent of the features in the collection.
           type: object
           properties:
             bbox:
@@ -521,13 +656,63 @@ components:
               minItems: 1
               items:
                 description: >-
-                  West, south, east, north edges of the bounding box. The
-                  coordinates
+                  Each bounding box is provided as four or six numbers,
+                  depending on
 
-                  are in the coordinate reference system specified in `crs`. By
-                  default
+                  whether the coordinate reference system includes a vertical
+                  axis
 
-                  this is WGS 84 longitude/latitude.
+                  (height or depth):
+
+
+                  * Lower left corner, coordinate axis 1
+
+                  * Lower left corner, coordinate axis 2
+
+                  * Minimum value, coordinate axis 3 (optional)
+
+                  * Upper right corner, coordinate axis 1
+
+                  * Upper right corner, coordinate axis 2
+
+                  * Maximum value, coordinate axis 3 (optional)
+
+
+                  The coordinate reference system of the values is WGS 84
+                  longitude/latitude
+
+                  (http://www.opengis.net/def/crs/OGC/1.3/CRS84) unless a
+                  different coordinate
+
+                  reference system is specified in `crs`.
+
+
+                  For WGS 84 longitude/latitude the values are in most cases the
+                  sequence of
+
+                  minimum longitude, minimum latitude, maximum longitude and
+                  maximum latitude.
+
+                  However, in cases where the box spans the antimeridian the
+                  first value
+
+                  (west-most box edge) is larger than the third value (east-most
+                  box edge).
+
+
+                  If the vertical axis is included, the third and the sixth
+                  number are
+
+                  the bottom and the top of the 3-dimensional bounding box.
+
+
+                  If a feature has multiple spatial geometry properties, it is
+                  the decision of the
+
+                  server whether only a single spatial geometry property is used
+                  to determine
+
+                  the extent or all relevant geometries.
                 type: array
                 minItems: 4
                 maxItems: 6
@@ -557,6 +742,8 @@ components:
               enum:
                 - 'http://www.opengis.net/def/crs/OGC/1.3/CRS84'
               default: 'http://www.opengis.net/def/crs/OGC/1.3/CRS84'
+          required:
+            - bbox
         temporal:
           description: The temporal extent of the features in the collection.
           type: object
@@ -615,6 +802,11 @@ components:
               enum:
                 - 'http://www.opengis.net/def/uom/ISO-8601/0/Gregorian'
               default: 'http://www.opengis.net/def/uom/ISO-8601/0/Gregorian'
+          required:
+            - interval
+      required:
+        - spatial
+        - temporal
     featureCollectionGeoJSON:
       type: object
       required:
@@ -628,20 +820,17 @@ components:
         features:
           type: array
           items:
-            $ref: '#/components/schemas/featureGeoJSON'
+            $ref: '#/components/schemas/item'
         links:
           type: array
           items:
             $ref: '#/components/schemas/link'
         timeStamp:
-          type: string
-          format: date-time
+          $ref: '#/components/schemas/timeStamp'
         numberMatched:
-          type: integer
-          minimum: 0
+          $ref: '#/components/schemas/numberMatched'
         numberReturned:
-          type: integer
-          minimum: 0
+          $ref: '#/components/schemas/numberReturned'
     featureGeoJSON:
       type: object
       required:
@@ -693,6 +882,9 @@ components:
       type: object
       required:
         - links
+        - stac_version
+        - id
+        - description
       properties:
         title:
           type: string
@@ -706,6 +898,12 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/link'
+        stac_version:
+          $ref: '#/components/schemas/stac_version'
+        stac_extensions:
+          $ref: '#/components/schemas/stac_extensions'
+        id:
+          type: string
     linestringGeoJSON:
       type: object
       required:
@@ -726,6 +924,9 @@ components:
               type: number
     link:
       type: object
+      required:
+        - href
+        - rel
       properties:
         href:
           type: string
@@ -736,7 +937,7 @@ components:
           example: child
         type:
           type: string
-          example: application/json
+          example: application/geo+json
         hreflang:
           type: string
           example: en
@@ -745,11 +946,39 @@ components:
           example: NAIP Child Catalog
         length:
           type: integer
+        method:
+          type: string
+          enum:
+            - GET
+            - POST
+          default: GET
+          description: Specifies the HTTP method that the link expects
+        headers:
+          type: object
+          description: Object key values pairs they map to headers
+          example:
+            Accept: application/json
+        body:
+          type: object
+          description: >-
+            For POST requests, the link can specify the HTTP body as a JSON
+            object.
+        merge:
+          type: boolean
+          default: false
+          description: |-
+            This is only valid when the server is responding to POST request.
+
+            If merge is true, the client is expected to merge the body value
+            into the current request body before following the link.
+            This avoids passing large post bodies back and forth when following
+            links, particularly for navigating pages through the `POST /search`
+            endpoint.
+
+            NOTE: To support form encoding it is expected that a client be able
+            to merge in the key value pairs specified as JSON
+            `{"next": "token"}` will become `&next=token`.
       title: Link
-      description: A generic link.
-      required:
-        - href
-        - rel
     multilinestringGeoJSON:
       type: object
       required:
@@ -809,6 +1038,25 @@ components:
                 minItems: 2
                 items:
                   type: number
+    numberMatched:
+      description: |-
+        The number of features of the feature type that match the selection
+        parameters like `bbox`.
+      type: integer
+      minimum: 0
+      example: 127
+    numberReturned:
+      description: |-
+        The number of features in the feature collection.
+
+        A server may omit this information in a response, if the information
+        about the number of features is not known or difficult to compute.
+
+        If the value is provided, the value shall be identical to the number
+        of items in the "features" array.
+      type: integer
+      minimum: 0
+      example: 10
     pointGeoJSON:
       type: object
       required:
@@ -844,6 +1092,92 @@ components:
               minItems: 2
               items:
                 type: number
+    timeStamp:
+      description: >-
+        This property indicates the time and date when the response was
+        generated.
+      type: string
+      format: date-time
+      example: '2017-08-17T08:05:32Z'
+    description:
+      type: string
+      description: |-
+        Detailed multi-line description to fully explain the catalog or
+        collection.
+
+        [CommonMark 0.29](http://commonmark.org/) syntax MAY be used for rich
+        text representation.
+    license:
+      type: string
+      description: |-
+        License(s) of the data as a SPDX
+        [License identifier](https://spdx.org/licenses/). Alternatively, use
+        `proprietary` if the license is not on the SPDX license list or
+        `various` if multiple licenses apply. In these two cases links to the
+        license texts SHOULD be added, see the `license` link relation type.
+
+        Non-SPDX licenses SHOULD add a link to the license text with the
+        `license` relation in the links section. The license text MUST NOT be
+        provided as a value of this field. If there is no public license URL
+        available, it is RECOMMENDED to host the license text and
+        link to it.
+      example: Apache-2.0
+    providers:
+      type: array
+      description: >-
+        A list of providers, which may include all organizations capturing or
+        processing the data or the hosting provider. Providers should be listed
+        in chronological order with the most recent provider being the last
+        element of the list.
+      items:
+        type: object
+        title: Provider
+        required:
+          - name
+        properties:
+          name:
+            description: The name of the organization or the individual.
+            type: string
+          description:
+            description: >-
+              Multi-line description to add further provider information such as
+              processing details for processors and producers, hosting details
+              for hosts or basic contact information.
+
+
+              CommonMark 0.29 syntax MAY be used for rich text representation.
+            type: string
+          roles:
+            description: |-
+              Roles of the provider.
+
+              The provider's role(s) can be one or more of the following
+              elements:
+
+              * licensor: The organization that is licensing the dataset under
+                the license specified in the collection's license field.
+              * producer: The producer of the data is the provider that
+                initially captured and processed the source data, e.g. ESA for
+                Sentinel-2 data.
+              * processor: A processor is any provider who processed data to a
+                derived product.
+              * host: The host is the actual provider offering the data on their
+                storage. There should be no more than one host, specified as last
+                element of the list.
+            type: array
+            items:
+              type: string
+              enum:
+                - producer
+                - licensor
+                - processor
+                - host
+          url:
+            description: >-
+              Homepage on which the provider describes the dataset and publishes
+              contact information.
+            type: string
+            format: url
     searchBody:
       description: The search criteria
       type: object
@@ -851,13 +1185,18 @@ components:
         - $ref: '#/components/schemas/bboxFilter'
         - $ref: '#/components/schemas/datetimeFilter'
         - $ref: '#/components/schemas/intersectsFilter'
-        - type: object
-          properties:
-            limit:
-              type: integer
-              example: 10
+        - $ref: '#/components/schemas/collectionsFilter'
+        - $ref: '#/components/schemas/idsFilter'
+        - $ref: '#/components/schemas/limitFilter'
+    limit:
+      type: integer
+      minimum: 1
+      example: 10
+      default: 10
+      maximum: 10000
+      description: The maximum number of results to return (page size). Defaults to 10
     bbox:
-      description: |
+      description: |-
         Only features that have a geometry that intersects the bounding box are
         selected. The bounding box is provided as four or six numbers,
         depending on whether the coordinate reference system includes a
@@ -881,10 +1220,14 @@ components:
         first value (west-most box edge) is larger than the third value
         (east-most box edge).
 
-
         If a feature has multiple spatial geometry properties, it is the
         decision of the server whether only a single spatial geometry property
         is used to determine the extent or all relevant geometries.
+
+        Example: The bounding box of the New Zealand Exclusive Economic Zone in
+        WGS 84 (from 160.6°E to 170°W and from 55.95°S to 25.89°S) would be
+        represented in JSON as `[160.6, -55.95, -170, -25.89]` and in a query as
+        `bbox=160.6,-55.95,-170,-25.89`.
       type: array
       minItems: 4
       maxItems: 6
@@ -901,6 +1244,20 @@ components:
       properties:
         bbox:
           $ref: '#/components/schemas/bbox'
+    collectionsArray:
+      type: array
+      description: |-
+        Array of Collection IDs to include in the search for items.
+        Only Items in one of the provided Collections will be searched.
+      items:
+        type: string
+    ids:
+      type: array
+      description: |-
+        Array of Item ids to return. All other filter parameters that further
+        restrict the number of search results are ignored
+      items:
+        type: string
     datetimeFilter:
       description: An object representing a date+time based filter.
       type: object
@@ -913,40 +1270,48 @@ components:
       properties:
         intersects:
           $ref: 'https://geojson.org/schema/Geometry.json'
+    limitFilter:
+      type: object
+      description: Only returns maximum number of results (page size)
+      properties:
+        limit:
+          $ref: '#/components/schemas/limit'
+    idsFilter:
+      type: object
+      description: Only returns items that match the array of given ids
+      properties:
+        ids:
+          $ref: '#/components/schemas/ids'
+    collectionsFilter:
+      type: object
+      description: Only returns the collections specified
+      properties:
+        collections:
+          $ref: '#/components/schemas/collectionsArray'
     datetime:
       type: string
-      description: >-
+      description: |-
         Either a date-time or an interval, open or closed. Date and time
-        expressions
-
-        adhere to RFC 3339. Open intervals are expressed using double-dots.
-
+        expressions adhere to RFC 3339. Open intervals are expressed using
+        double-dots.
 
         Examples:
 
-
         * A date-time: "2018-02-12T23:20:50Z"
-
         * A closed interval: "2018-02-12T00:00:00Z/2018-03-18T12:31:12Z"
-
         * Open intervals: "2018-02-12T00:00:00Z/.." or "../2018-03-18T12:31:12Z"
 
-
         Only features that have a temporal property that intersects the value of
-
         `datetime` are selected.
 
-
         If a feature has multiple temporal properties, it is the decision of the
-
         server whether only a single temporal property is used to determine
-
         the extent or all relevant temporal properties.
       example: '2018-02-12T00:00:00Z/2018-03-18T12:31:12Z'
     stac_version:
       title: STAC version
       type: string
-      example: 0.8.0
+      example: 0.9.0
     stac_extensions:
       title: STAC extensions
       type: array
@@ -958,53 +1323,6 @@ components:
             format: uri
           - title: Reference to a core extension
             type: string
-    catalogDefinition:
-      type: object
-      required:
-        - stac_version
-        - id
-        - description
-        - links
-      properties:
-        stac_version:
-          $ref: '#/components/schemas/stac_version'
-        stac_extensions:
-          $ref: '#/components/schemas/stac_extensions'
-        id:
-          type: string
-          example: naip
-        title:
-          type: string
-          example: NAIP Imagery
-        description:
-          type: string
-          example: Catalog of NAIP Imagery.
-        links:
-          type: array
-          items:
-            anyOf:
-              - $ref: '#/components/schemas/link'
-              - title: Link to search endpoint
-                description: >-
-                  Link the search endpoint, which is **required** to be
-                  specified if the API implements `/stac/search`.
-                type: object
-                required:
-                  - href
-                  - rel
-                properties:
-                  href:
-                    type: string
-                    format: url
-                    example: 'http://www.cool-sat.com/stac/search'
-                  rel:
-                    type: string
-                    enum:
-                      - search
-                  type:
-                    type: string
-                  title:
-                    type: string
     itemCollection:
       description: >-
         A GeoJSON FeatureCollection augmented with foreign members that contain
@@ -1060,9 +1378,13 @@ components:
         assets:
           $ref: '#/components/schemas/itemAssets'
       example:
-        stac_version: 0.8.0
+        stac_version: 0.9.0
+        stac_extensions:
+          - eo
+          - view
+          - 'https://example.com/cs-extension/1.0/schema.json'
         type: Feature
-        id: CS3-20160503_132130_04
+        id: CS3-20160503_132131_05
         bbox:
           - -122.59750209
           - 37.48803556
@@ -1082,21 +1404,43 @@ components:
               - - -122.308150179
                 - 37.488035566
         properties:
-          datetime: '2016-05-03T13:21:30.040Z'
+          datetime: '2016-05-03T13:22:30.040Z'
+          title: A CS3 item
+          license: PDDL-1.0
+          providers:
+            - name: CoolSat
+              roles:
+                - producer
+                - licensor
+              url: 'https://cool-sat.com/'
+          'view:sun_azimuth': 168.7
+          'eo:cloud_cover': 0.12
+          'view:off_nadir': 1.4
+          platform: coolsat2
+          instruments:
+            - cool_sensor_v1
+          'eo:bands': []
+          'view:sun_elevation': 33.4
+          'eo:gsd': 0.512
+        collection: CS3
         links:
           - rel: self
-            href: >-
-              http://cool-sat.com/catalog/collections/cs/items/CS3-20160503_132130_04.json
+            href: 'http://cool-sat.com/collections/CS3/items/20160503_132130_04'
+          - rel: root
+            href: 'http://cool-sat.com/collections'
+          - rel: parent
+            href: 'http://cool-sat.com/collections/CS3'
+          - rel: collection
+            href: 'http://cool-sat.com/collections/CS3'
         assets:
           analytic:
+            href: >-
+              http://cool-sat.com/static-catalog/CS3/20160503_132130_04/analytic.tif
             title: 4-Band Analytic
-            href: >-
-              http://cool-sat.com/catalog/collections/cs/items/CS3-20160503_132130_04/analytic.tif
           thumbnail:
-            title: Thumbnail
             href: >-
-              http://cool-sat.com/catalog/collections/cs/items/CS3-20160503_132130_04/thumb.png
-            type: image/png
+              http://cool-sat.com/static-catalog/CS3/20160503_132130_04/thumbnail.png
+            title: Thumbnail
     itemId:
       type: string
       example: path/to/example.tif
@@ -1123,10 +1467,25 @@ components:
             type: string
             description: Displayed title
             example: Thumbnail
+          description:
+            type: string
+            description: |-
+              Multi-line description to explain the asset.
+
+              [CommonMark 0.29](http://commonmark.org/) syntax MAY be used for
+              rich text representation.
+            example: Small 256x256px PNG thumbnail for a preview.
           type:
             type: string
             description: Media type of the asset
             example: image/png
+          roles:
+            type: array
+            items:
+              type: string
+            description: Purposes of the asset
+            example:
+              - thumbnail
     itemProperties:
       type: object
       required:
@@ -1149,25 +1508,27 @@ components:
       example:
         - rel: next
           href: >-
-            http://api.cool-sat.com/stac/search?next=ANsXtp9mrqN0yrKWhf-y2PUpHRLQb1GT-mtxNcXou8TwkXhi1Jbk
+            http://api.cool-sat.com/search?next=ANsXtp9mrqN0yrKWhf-y2PUpHRLQb1GT-mtxNcXou8TwkXhi1Jbk
   responses:
     LandingPage:
       description: |-
-        The landing page provides links to the API definition 
-        (link relations `service-desc` and `service-doc`), 
-        the Conformance declaration (path `/conformance`, 
-        link relation `conformance`), and the Feature 
-        Collections (path `/collections`, link relation 
+        The landing page provides links to the API definition
+        (link relations `service-desc` and `service-doc`),
+        the Conformance declaration (path `/conformance`,
+        link relation `conformance`), and the Feature
+        Collections (path `/collections`, link relation
         `data`).
+
+        Links to the search endpoints (path `/search`, link relation `search`,
+        method `GET` or `POST`) are **required** to be specified if the API
+        implements `/search` for any of the specified HTTP methods.
       content:
         application/json:
           schema:
             $ref: '#/components/schemas/landingPage'
           example:
-            title: Buildings in Bonn
-            description: >-
-              Access to data about buildings in the city of Bonn via a Web API
-              that conforms to the OGC API Features specification.
+            title: NAIP Imagery
+            description: Catalog of NAIP Imagery.
             links:
               - href: 'http://data.example.org/'
                 rel: self
@@ -1189,6 +1550,12 @@ components:
                 rel: data
                 type: application/json
                 title: Information about the feature collections
+              - href: 'http://data.example.org/search'
+                rel: search
+                type: application/json
+                title: Search across feature collections
+            stac_version: 0.9.0
+            id: naip
         text/html:
           schema:
             type: string
@@ -1196,9 +1563,9 @@ components:
       description: |-
         The URIs of all conformance classes supported by the server.
 
-        To support "generic" clients that want to access multiple 
-        OGC API Features implementations - and not "just" a specific 
-        API / server, the server declares the conformance 
+        To support "generic" clients that want to access multiple
+        OGC API Features implementations - and not "just" a specific
+        API / server, the server declares the conformance
         classes it implements and conforms to.
       content:
         application/json:
@@ -1219,18 +1586,18 @@ components:
 
 
         The dataset is organized as one or more feature collections. This
-        resource 
+        resource
 
-        provides information about and access to the collections. 
+        provides information about and access to the collections.
 
 
         The response contains the list of collections. For each collection, a
-        link 
+        link
 
         to the items in the collection (path
-        `/collections/{collectionId}/items`, 
+        `/collections/{collectionId}/items`,
 
-        link relation `items`) as well as key information about the collection. 
+        link relation `items`) as well as key information about the collection.
 
         This information includes:
 
@@ -1254,57 +1621,6 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/collections'
-          example:
-            links:
-              - href: 'http://data.example.org/collections.json'
-                rel: self
-                type: application/json
-                title: this document
-              - href: 'http://data.example.org/collections.html'
-                rel: alternate
-                type: text/html
-                title: this document as HTML
-              - href: 'http://schemas.example.org/1.0/buildings.xsd'
-                rel: describedBy
-                type: application/xml
-                title: GML application schema for Acme Corporation building data
-              - href: 'http://download.example.org/buildings.gpkg'
-                rel: enclosure
-                type: application/geopackage+sqlite3
-                title: Bulk download (GeoPackage)
-                length: 472546
-            collections:
-              - id: buildings
-                title: Buildings
-                description: Buildings in the city of Bonn.
-                extent:
-                  spatial:
-                    bbox:
-                      - - 7.01
-                        - 50.63
-                        - 7.22
-                        - 50.78
-                  temporal:
-                    interval:
-                      - - '2010-02-15T12:34:56Z'
-                        - null
-                links:
-                  - href: 'http://data.example.org/collections/buildings/items'
-                    rel: items
-                    type: application/geo+json
-                    title: Buildings
-                  - href: 'http://data.example.org/collections/buildings/items.html'
-                    rel: items
-                    type: text/html
-                    title: Buildings
-                  - href: 'https://creativecommons.org/publicdomain/zero/1.0/'
-                    rel: license
-                    type: text/html
-                    title: CC0-1.0
-                  - href: 'https://creativecommons.org/publicdomain/zero/1.0/rdf'
-                    rel: license
-                    type: application/rdf+xml
-                    title: CC0-1.0
         text/html:
           schema:
             type: string
@@ -1313,11 +1629,11 @@ components:
         Information about the feature collection with id `collectionId`.
 
 
-        The response contains a linkto the items in the collection 
+        The response contains a link to the items in the collection
 
-        (path `/collections/{collectionId}/items`,link relation `items`) 
+        (path `/collections/{collectionId}/items`, link relation `items`)
 
-        as well as key information about the collection. This information 
+        as well as key information about the collection. This information
 
         includes:
 
@@ -1341,124 +1657,52 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/collection'
-          example:
-            id: buildings
-            title: Buildings
-            description: Buildings in the city of Bonn.
-            extent:
-              spatial:
-                bbox:
-                  - - 7.01
-                    - 50.63
-                    - 7.22
-                    - 50.78
-              temporal:
-                interval:
-                  - - '2010-02-15T12:34:56Z'
-                    - null
-            links:
-              - href: 'http://data.example.org/collections/buildings/items'
-                rel: items
-                type: application/geo+json
-                title: Buildings
-              - href: 'http://data.example.org/collections/buildings/items.html'
-                rel: items
-                type: text/html
-                title: Buildings
-              - href: 'https://creativecommons.org/publicdomain/zero/1.0/'
-                rel: license
-                type: text/html
-                title: CC0-1.0
-              - href: 'https://creativecommons.org/publicdomain/zero/1.0/rdf'
-                rel: license
-                type: application/rdf+xml
-                title: CC0-1.0
         text/html:
           schema:
             type: string
     Features:
       description: >-
-        The response is a document consisting of features in the collection. 
+        The response is a document consisting of features in the collection.
 
-        The features included in the response are determined by the server 
+        The features included in the response are determined by the server
 
-        based on the query parameters of the request. To support access to 
+        based on the query parameters of the request. To support access to
 
-        larger collections without overloading the client, the API supports 
+        larger collections without overloading the client, the API supports
 
-        paged access with links to the next page, if more features are selected 
+        paged access with links to the next page, if more features are selected
 
         that the page size.
 
 
-        The `bbox` and `datetime` parameter can be used to select only a 
+        The `bbox` and `datetime` parameter can be used to select only a
 
-        subset of the features in the collection (the features that are in the 
+        subset of the features in the collection (the features that are in the
 
         bounding box or time interval). The `bbox` parameter matches all
-        features 
+        features
 
-        in the collection that are not associated with a location, too. The 
+        in the collection that are not associated with a location, too. The
 
-        `datetime` parameter matches all features in the collection that are 
+        `datetime` parameter matches all features in the collection that are
 
         not associated with a time stamp or interval, too.
 
 
-        The `limit` parameter may be used to control the subset of the 
+        The `limit` parameter may be used to control the subset of the
 
         selected features that should be returned in the response, the page
         size.
 
-        Each page may include information about the number of selected and 
+        Each page may include information about the number of selected and
 
-        returned features (`numberMatched` and `numberReturned`) as well as 
+        returned features (`numberMatched` and `numberReturned`) as well as
 
         links to support paging (link relation `next`).
       content:
         application/geo+json:
           schema:
             $ref: '#/components/schemas/featureCollectionGeoJSON'
-          example:
-            type: FeatureCollection
-            links:
-              - href: 'http://data.example.com/collections/buildings/items.json'
-                rel: self
-                type: application/geo+json
-                title: this document
-              - href: 'http://data.example.com/collections/buildings/items.html'
-                rel: alternate
-                type: text/html
-                title: this document as HTML
-              - href: >-
-                  http://data.example.com/collections/buildings/items.json&offset=10&limit=2
-                rel: next
-                type: application/geo+json
-                title: next page
-            timeStamp: '2018-04-03T14:52:23Z'
-            numberMatched: 123
-            numberReturned: 2
-            features:
-              - type: Feature
-                id: '123'
-                geometry:
-                  type: Polygon
-                  coordinates:
-                    - ...
-                properties:
-                  function: residential
-                  floors: '2'
-                  lastUpdate: '2015-08-01T12:34:56Z'
-              - type: Feature
-                id: '132'
-                geometry:
-                  type: Polygon
-                  coordinates:
-                    - ...
-                properties:
-                  function: public use
-                  floors: '10'
-                  lastUpdate: '2013-12-03T10:15:37Z'
         text/html:
           schema:
             type: string
@@ -1469,34 +1713,7 @@ components:
       content:
         application/geo+json:
           schema:
-            $ref: '#/components/schemas/featureGeoJSON'
-          example:
-            type: Feature
-            links:
-              - href: 'http://data.example.com/id/building/123'
-                rel: canonical
-                title: canonical URI of the building
-              - href: 'http://data.example.com/collections/buildings/items/123.json'
-                rel: self
-                type: application/geo+json
-                title: this document
-              - href: 'http://data.example.com/collections/buildings/items/123.html'
-                rel: alternate
-                type: text/html
-                title: this document as HTML
-              - href: 'http://data.example.com/collections/buildings'
-                rel: collection
-                type: application/geo+json
-                title: the collection document
-            id: '123'
-            geometry:
-              type: Polygon
-              coordinates:
-                - ...
-            properties:
-              function: residential
-              floors: '2'
-              lastUpdate: '2015-08-01T12:34:56Z'
+            $ref: '#/components/schemas/item'
         text/html:
           schema:
             type: string

--- a/search/lib/api/stac.js
+++ b/search/lib/api/stac.js
@@ -53,7 +53,7 @@ async function getCatalog (request, response) {
   const catalog = createDefaultCatalog(request.apiGateway.event);
 
   cmrCollections.forEach((item) => {
-    if (item.href.includes('providers')) {
+    if (typeof item.href === 'string' && item.href.includes('providers')) {
       catalog.addNext(item.title, `/${item.id}`);
     }
     catalog.addChild(item.title, `/${item.id}`);

--- a/search/lib/api/stac.js
+++ b/search/lib/api/stac.js
@@ -53,8 +53,12 @@ async function getCatalog (request, response) {
   const catalog = createDefaultCatalog(request.apiGateway.event);
 
   cmrCollections.forEach((item) => {
+    if (item.href.includes('providers')) {
+      catalog.addNext(item.title, `/${item.id}`)
+    }
     catalog.addChild(item.title, `/${item.id}`);
   });
+
 
   response.status(200).json(catalog);
 }

--- a/search/lib/api/stac.js
+++ b/search/lib/api/stac.js
@@ -54,11 +54,10 @@ async function getCatalog (request, response) {
 
   cmrCollections.forEach((item) => {
     if (item.href.includes('providers')) {
-      catalog.addNext(item.title, `/${item.id}`)
+      catalog.addNext(item.title, `/${item.id}`);
     }
     catalog.addChild(item.title, `/${item.id}`);
   });
-
 
   response.status(200).json(catalog);
 }

--- a/search/lib/stac/catalog.js
+++ b/search/lib/stac/catalog.js
@@ -27,7 +27,7 @@ class Catalog {
   }
 
   addNext (title, relativeUrl) {
-    const root = this.links.find((l) => l.rel === this.links.RELATION_TYPES.next);
+    const root = this.links.find((l) => l.rel === this.links.RELATION_TYPES.child);
     const next = link.createNext(title, `${root.href}${relativeUrl}`);
     this.links.push(next);
   }

--- a/search/lib/stac/catalog.js
+++ b/search/lib/stac/catalog.js
@@ -27,9 +27,9 @@ class Catalog {
   }
 
   addNext (title, relativeUrl) {
-    const root = this.links.find((l) => l.rel === this.links.RELATION_TYPES.next)
-    const next = link.createNext(title, `${root.href}${relativeUrl}`)
-    this.links.push(next)
+    const root = this.links.find((l) => l.rel === this.links.RELATION_TYPES.next);
+    const next = link.createNext(title, `${root.href}${relativeUrl}`);
+    this.links.push(next);
   }
 }
 

--- a/search/lib/stac/catalog.js
+++ b/search/lib/stac/catalog.js
@@ -25,6 +25,12 @@ class Catalog {
     const child = link.createChild(title, `${root.href}${relativeUrl}`);
     this.links.push(child);
   }
+
+  addNext (title, relativeUrl) {
+    const root = this.links.find((l) => l.rel === this.links.RELATION_TYPES.next)
+    const next = link.createNext(title, `${root.href}${relativeUrl}`)
+    this.links.push(next)
+  }
 }
 
 function createRootCatalog (stacBaseUrl) {

--- a/search/lib/stac/catalog.js
+++ b/search/lib/stac/catalog.js
@@ -27,7 +27,7 @@ class Catalog {
   }
 
   addNext (title, relativeUrl) {
-    const root = this.links.find((l) => l.rel === this.links.RELATION_TYPES.child);
+    const root = this.links.find((l) => l.rel === link.RELATION_TYPES.self);
     const next = link.createNext(title, `${root.href}${relativeUrl}`);
     this.links.push(next);
   }

--- a/search/lib/stac/link.js
+++ b/search/lib/stac/link.js
@@ -3,7 +3,8 @@ const RELATION_TYPES = {
   root: 'root',
   parent: 'parent',
   child: 'child',
-  item: 'item'
+  item: 'item',
+  next: 'next'
 };
 
 const MEDIA_TYPES = {
@@ -30,6 +31,10 @@ function createItem (title, href, type) {
   return create(RELATION_TYPES.item, title, href, type);
 }
 
+function createNext(title, href, type) {
+  return create(RELATION_TYPES.next, title, href, type)
+}
+
 function create (rel, title, href, type = MEDIA_TYPES.json) {
   return { rel, title, href, type };
 }
@@ -42,5 +47,6 @@ module.exports = {
   createParent,
   createChild,
   createItem,
+  createNext,
   create
 };

--- a/search/lib/stac/link.js
+++ b/search/lib/stac/link.js
@@ -31,8 +31,8 @@ function createItem (title, href, type) {
   return create(RELATION_TYPES.item, title, href, type);
 }
 
-function createNext(title, href, type) {
-  return create(RELATION_TYPES.next, title, href, type)
+function createNext (title, href, type) {
+  return create(RELATION_TYPES.next, title, href, type);
 }
 
 function create (rel, title, href, type = MEDIA_TYPES.json) {

--- a/search/tests/stac/catalog.spec.js
+++ b/search/tests/stac/catalog.spec.js
@@ -54,9 +54,9 @@ describe('createRootCatalog', () => {
   it('should be able to add a next rel to pagination links', () => {
     rootCatalog = createRootCatalog('/cmr-stac/stac/provider');
     rootCatalog.addNext('Page 2', '/page/2');
-    const paginationLink = rootCatalog.links.find(link => link.rel === 'next')
+    const paginationLink = rootCatalog.links.find(link => link.rel === 'next');
     expect(paginationLink).toBeDefined();
-    expect(paginationLink.rel).toBe('next')
+    expect(paginationLink.rel).toBe('next');
     expect(paginationLink.href).toBe('/cmr-stac/stac/provider/page/2');
   });
 });

--- a/search/tests/stac/catalog.spec.js
+++ b/search/tests/stac/catalog.spec.js
@@ -53,11 +53,10 @@ describe('createRootCatalog', () => {
 
   it('should be able to add a next rel to pagination links', () => {
     rootCatalog = createRootCatalog('/cmr-stac/stac/provider');
-    rootCatalog.addNext('Pagination Link', '/10');
+    rootCatalog.addNext('Page 2', '/page/2');
     const paginationLink = rootCatalog.links.find(link => link.rel === 'next')
-    console.log(paginationLink)
     expect(paginationLink).toBeDefined();
     expect(paginationLink.rel).toBe('next')
-    expect(paginationLink.href).toBe('/cmr-stac/stac/provider/10');
+    expect(paginationLink.href).toBe('/cmr-stac/stac/provider/page/2');
   });
 });

--- a/search/tests/stac/catalog.spec.js
+++ b/search/tests/stac/catalog.spec.js
@@ -50,4 +50,11 @@ describe('createRootCatalog', () => {
     expect(childLink).toBeDefined();
     expect(childLink.href).toBe('/cmr-stac/stac/default');
   });
+
+  it('should be able to add a next rel to pagination links', () => {
+    rootCatalog.addChild('Pagination Link', '/provider');
+    const paginationLink = rootCatalog.links.find((link) => link.rel === 'child');
+    expect(paginationLink).toBeDefined();
+    expect(paginationLink.href).toBe('/cmr-stac/stac/provider');
+  });
 });

--- a/search/tests/stac/catalog.spec.js
+++ b/search/tests/stac/catalog.spec.js
@@ -52,9 +52,12 @@ describe('createRootCatalog', () => {
   });
 
   it('should be able to add a next rel to pagination links', () => {
-    rootCatalog.addChild('Pagination Link', '/provider');
-    const paginationLink = rootCatalog.links.find((link) => link.rel === 'child');
+    rootCatalog = createRootCatalog('/cmr-stac/stac/provider');
+    rootCatalog.addNext('Pagination Link', '/10');
+    const paginationLink = rootCatalog.links.find(link => link.rel === 'next')
+    console.log(paginationLink)
     expect(paginationLink).toBeDefined();
-    expect(paginationLink.href).toBe('/cmr-stac/stac/provider');
+    expect(paginationLink.rel).toBe('next')
+    expect(paginationLink.href).toBe('/cmr-stac/stac/provider/10');
   });
 });

--- a/search/tests/stac/link.spec.js
+++ b/search/tests/stac/link.spec.js
@@ -25,6 +25,10 @@ describe('Link', () => {
     expect(link.createChild().rel).toBe('child');
   });
 
+  it('should be able to create a next link.', () => {
+    expect(link.createNext().rel).toBe('next');
+  });
+
   it('should be able to create an item link.', () => {
     expect(link.createItem().rel).toBe('item');
   });


### PR DESCRIPTION
This ticket was created due to a bug where links pointing to the next page in a collection were using `rel=child` when they should be using `rel=next`. To fix this I did the following:

Inside of `/lib/stac/link.js` I added key-value pair of `next: 'next'` to RELATION_TYPES`. In addition to that I created a function called `createNext` which follows the same pattern of most of the other functions in the file.

Inside of `/lib/stac/catalog.js` I created an `addNext` function inside of the `Catalog` class which essentially updates an object to `rel: 'next'` and pushes it to the links array.

Inside of `/lib/api/stac.js` I created updated the `forEach` inside of `getCatalog` that looks for any object that includes the word `providers` inside of a link and runs the `addnext` function on that object.