### PR TITLE
[SCV-24] Question Marks In Self Links

### DIFF
--- a/search/lib/stac/link.js
+++ b/search/lib/stac/link.js
@@ -14,7 +14,10 @@ function createRoot (title, href, type) {
   return create(RELATION_TYPES.root, title, href, type);
 }
 
-function createSelf (title, href, type) {
+function createSelf (title, href = '', type) {
+  if (href.includes('?')) {
+    return create(RELATION_TYPES.self, title, href.slice(0, -1), type);
+  }
   return create(RELATION_TYPES.self, title, href, type);
 }
 

--- a/search/tests/stac/catalog.spec.js
+++ b/search/tests/stac/catalog.spec.js
@@ -22,13 +22,13 @@ describe('createRootCatalog', () => {
   });
 
   it('should create a catalog with a self link that does not contain a question mark.', () => {
-    const newRootCatalog = createRootCatalog('/cmr-stac/stac?')
+    const newRootCatalog = createRootCatalog('/cmr-stac/stac?');
     const selfLink = newRootCatalog.links.find((link) => link.rel === 'self');
-    expect(selfLink).toBeDefined()
+    expect(selfLink).toBeDefined();
     expect(selfLink.href).toBe('/cmr-stac/stac');
     expect(selfLink.type).toBe('application/json');
     expect(selfLink.title).toBe('Root Catalog');
-  })
+  });
 
   it('should create a catalog with a root link to itself.', () => {
     const selfLink = rootCatalog.links.find((link) => link.rel === 'self');

--- a/search/tests/stac/catalog.spec.js
+++ b/search/tests/stac/catalog.spec.js
@@ -21,6 +21,15 @@ describe('createRootCatalog', () => {
     expect(selfLink.title).toBe('Root Catalog');
   });
 
+  it('should create a catalog with a self link that does not contain a question mark.', () => {
+    const newRootCatalog = createRootCatalog('/cmr-stac/stac?')
+    const selfLink = newRootCatalog.links.find((link) => link.rel === 'self');
+    expect(selfLink).toBeDefined()
+    expect(selfLink.href).toBe('/cmr-stac/stac');
+    expect(selfLink.type).toBe('application/json');
+    expect(selfLink.title).toBe('Root Catalog');
+  })
+
   it('should create a catalog with a root link to itself.', () => {
     const selfLink = rootCatalog.links.find((link) => link.rel === 'self');
     const rootLink = rootCatalog.links.find((link) => link.rel === 'root');


### PR DESCRIPTION
The purpose of this ticket was to have question marks removed from the end of self links. I added a conditional statement inside of `createSelf` that checks to see if the string contains a question mark and if so it removes the last character in that string, where the question mark exists.