### PR TITLE
[SCV-30] Invalid Search Param

### DIFF
--- a/search/lib/cmr/index.js
+++ b/search/lib/cmr/index.js
@@ -9,7 +9,7 @@ const STAC_SEARCH_PARAMS_CONVERSION_MAP = {
   time: ['temporal', identity],
   intersects: ['polygon', (v) => _.flattenDeep(_.first(v.coordinates)).join(',')],
   limit: ['page_size', identity],
-  collectionId: ['collection_concept_id', identity]
+  collections: ['collection_concept_id', identity]
 };
 
 const STAC_QUERY_PARAMS_CONVERSION_MAP = {

--- a/search/package-lock.json
+++ b/search/package-lock.json
@@ -4663,10 +4663,12 @@
     },
     "fsevents": {
       "version": "1.2.9",
-      "resolved": "",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.9.tgz",
+      "integrity": "sha512-oeyj2H3EjjonWcFjD5NvZNE9Rqe4UW+nQBU2HNeKw0koVLEFIhtyETyAakeAM3de7Z/SW5kcA+fZUait9EApnw==",
       "dev": true,
       "optional": true,
       "requires": {
+        "nan": "^2.12.1",
         "node-pre-gyp": "^0.12.0"
       },
       "dependencies": {
@@ -9654,6 +9656,13 @@
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
       "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
       "dev": true
+    },
+    "nan": {
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
+      "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==",
+      "dev": true,
+      "optional": true
     },
     "nanomatch": {
       "version": "1.2.13",

--- a/search/tests/cmr/cmr.spec.js
+++ b/search/tests/cmr/cmr.spec.js
@@ -195,12 +195,12 @@ describe('cmr', () => {
         expect(result).toEqual({ page_size: 5 });
       });
 
-      it('should convert collection_concept_id to collectionId', () => {
+      it('should convert collection_concept_id to collections', () => {
         const params = {
-          collectionId: 1
+          collections: [1]
         };
         const result = convertParams(STAC_SEARCH_PARAMS_CONVERSION_MAP, params);
-        expect(result).toEqual({ collection_concept_id: 1 });
+        expect(result).toEqual({ collection_concept_id: [1] });
       });
     });
 


### PR DESCRIPTION
## Overview
This merge has a relatively minor change implemented. Previously, in the conversion from a `/stac/search` query payload to a CMR querystring, the converter was looking for a property called `colleciotnId`. That property was incorrect, and should have been `collections`. This branch makes that change to the STAC search parameter conversion map and associated tests.