### PR TITLE
[SCV-25] Browser Types

### DIFF
--- a/search/lib/convert/granules.js
+++ b/search/lib/convert/granules.js
@@ -94,13 +94,13 @@ function cmrGranToFeatureGeoJSON (event, cmrGran) {
       assets.browse.type = 'images/png';
     }
     if (browseLink.href.includes('.tiff')) {
-      assets.browse.type = 'images.tiff';
+      assets.browse.type = 'images/tiff';
     }
     if (browseLink.href.includes('.tif')) {
-      assets.browse.type = 'images.tiff';
+      assets.browse.type = 'images/tiff';
     }
     if (browseLink.href.includes('.raw')) {
-      assets.browse.type = 'images.raw';
+      assets.browse.type = 'images/raw';
     } else {
       assets.browse.type = 'images/jpeg';
     }

--- a/search/lib/convert/granules.js
+++ b/search/lib/convert/granules.js
@@ -91,22 +91,22 @@ function cmrGranToFeatureGeoJSON (event, cmrGran) {
     assets.browse = linkToAsset(browseLink);
 
     if (browseLink.href.includes('.jpg')) {
-      assets.browse.type = 'images/jpg'
+      assets.browse.type = 'images/jpg';
     }
     if (browseLink.href.includes('.jpeg')) {
-      assets.browse.type = 'images/jpeg'
+      assets.browse.type = 'images/jpeg';
     }
     if (browseLink.href.includes('.png')) {
-      assets.browse.type = 'images/png'
+      assets.browse.type = 'images/png';
     }
     if (browseLink.href.includes('.tiff')) {
-      assets.browse.type = 'images.tiff'
+      assets.browse.type = 'images.tiff';
     }
     if (browseLink.href.includes('.tif')) {
-      assets.browse.type = 'images.tif'
+      assets.browse.type = 'images.tif';
     }
     if (browseLink.href.includes('.raw')) {
-      assets.browse.type = 'images.raw'
+      assets.browse.type = 'images.raw';
     }
   }
   if (opendapLink) {

--- a/search/lib/convert/granules.js
+++ b/search/lib/convert/granules.js
@@ -89,6 +89,25 @@ function cmrGranToFeatureGeoJSON (event, cmrGran) {
   }
   if (browseLink) {
     assets.browse = linkToAsset(browseLink);
+
+    if (browseLink.href.includes('.jpg')) {
+      assets.browse.type = 'images/jpg'
+    }
+    if (browseLink.href.includes('.jpeg')) {
+      assets.browse.type = 'images/jpeg'
+    }
+    if (browseLink.href.includes('.png')) {
+      assets.browse.type = 'images/png'
+    }
+    if (browseLink.href.includes('.tiff')) {
+      assets.browse.type = 'images.tiff'
+    }
+    if (browseLink.href.includes('.tif')) {
+      assets.browse.type = 'images.tif'
+    }
+    if (browseLink.href.includes('.raw')) {
+      assets.browse.type = 'images.raw'
+    }
   }
   if (opendapLink) {
     assets.opendap = linkToAsset(opendapLink);

--- a/search/lib/convert/granules.js
+++ b/search/lib/convert/granules.js
@@ -93,9 +93,6 @@ function cmrGranToFeatureGeoJSON (event, cmrGran) {
     if (browseLink.href.includes('.jpg')) {
       assets.browse.type = 'images/jpg';
     }
-    if (browseLink.href.includes('.jpeg')) {
-      assets.browse.type = 'images/jpeg';
-    }
     if (browseLink.href.includes('.png')) {
       assets.browse.type = 'images/png';
     }
@@ -107,6 +104,9 @@ function cmrGranToFeatureGeoJSON (event, cmrGran) {
     }
     if (browseLink.href.includes('.raw')) {
       assets.browse.type = 'images.raw';
+    }
+    else {
+      assets.browse.type = 'images/jpeg';
     }
   }
   if (opendapLink) {

--- a/search/lib/convert/granules.js
+++ b/search/lib/convert/granules.js
@@ -90,9 +90,6 @@ function cmrGranToFeatureGeoJSON (event, cmrGran) {
   if (browseLink) {
     assets.browse = linkToAsset(browseLink);
 
-    if (browseLink.href.includes('.jpg')) {
-      assets.browse.type = 'images/jpg';
-    }
     if (browseLink.href.includes('.png')) {
       assets.browse.type = 'images/png';
     }
@@ -100,12 +97,11 @@ function cmrGranToFeatureGeoJSON (event, cmrGran) {
       assets.browse.type = 'images.tiff';
     }
     if (browseLink.href.includes('.tif')) {
-      assets.browse.type = 'images.tif';
+      assets.browse.type = 'images.tiff';
     }
     if (browseLink.href.includes('.raw')) {
       assets.browse.type = 'images.raw';
-    }
-    else {
+    } else {
       assets.browse.type = 'images/jpeg';
     }
   }

--- a/search/tests/convert/granules.spec.js
+++ b/search/tests/convert/granules.spec.js
@@ -160,12 +160,18 @@ describe('granuleToItem', () => {
       summary: 'summary',
       time_start: 0,
       time_end: 1,
+      assets: {},
       links: [
         {
           href: 'http://example.com/collections/id',
           rel: 'self',
           title: 'Info about this collection',
           type: 'application/json'
+        },
+        {
+          rel: 'http://esipfed.org/ns/fedsearch/1.1/browse#',
+          href: 'http://example.com/images/abc.jpg',
+          type: 'application/json' // this is wrong on purpose to test converting
         }
       ],
       data_center: 'USA',
@@ -186,7 +192,14 @@ describe('granuleToItem', () => {
           start_datetime: '0',
           end_datetime: '1'
         },
-        assets: {},
+        assets: {
+          browse: {
+            href: 'http://example.com/images/abc.jpg',
+            type: 'images/jpg',
+            name: undefined
+          }
+        },
+        bbox: undefined,
         links: [
           {
             rel: 'self',

--- a/search/tests/convert/granules.spec.js
+++ b/search/tests/convert/granules.spec.js
@@ -195,7 +195,7 @@ describe('granuleToItem', () => {
         assets: {
           browse: {
             href: 'http://example.com/images/abc.jpg',
-            type: 'images/jpg',
+            type: 'images/jpeg',
             name: undefined
           }
         },


### PR DESCRIPTION
The issue here was that `browse` types weren't being displayed. I added code to look at file extensions and either return `images/{determinedType}` or `images/jpeg` by default.