### PR TITLE
[SCV-14] Temporal Extent Incorrect for Most Collections

### DIFF
--- a/search/lib/convert/collections.js
+++ b/search/lib/convert/collections.js
@@ -49,7 +49,7 @@ function createExtent (cmrCollection) {
     trs: 'http://www.opengis.net/def/uom/ISO-8601/0/Gregorian',
     temporal: [
       cmrCollection.time_start,
-      (cmrCollection.time_end || cmrCollection.time_start)
+      (cmrCollection.time_end || null)
     ]
   };
 }

--- a/search/tests/convert/collections.spec.js
+++ b/search/tests/convert/collections.spec.js
@@ -98,8 +98,15 @@ describe('collections', () => {
       id: 'id',
       dataset_id: 'datasetId',
       summary: 'summary',
-      time_start: 0,
-      time_end: 1
+      time_start: '0',
+      time_end: '1'
+    };
+
+    const cmrCollTemporal = {
+      id: 'id',
+      dataset_id: 'datasetId',
+      summary: 'summary',
+      time_start: '2009-01-01T00:00:00Z'
     };
 
     const event = { headers: { Host: 'example.com' }, queryStringParameters: [] };
@@ -116,8 +123,67 @@ describe('collections', () => {
             90
           ],
           temporal: [
-            0,
-            1
+            '0',
+            '1'
+          ],
+          trs: 'http://www.opengis.net/def/uom/ISO-8601/0/Gregorian'
+        },
+        links: [
+          {
+            href: 'http://example.com/cmr-stac/collections/id',
+            rel: 'self',
+            title: 'Info about this collection',
+            type: 'application/json'
+          }, {
+            href: 'http://example.com/cmr-stac/stac/search?collectionId=id',
+            rel: 'stac',
+            title: 'STAC Search this collection',
+            type: 'application/json'
+          }, {
+            href: 'https://cmr.earthdata.nasa.gov/search/granules.json?collection_concept_id=id',
+            rel: 'cmr',
+            title: 'CMR Search this collection',
+            type: 'application/json'
+          }, {
+            href: 'http://example.com/cmr-stac/collections/id/items',
+            rel: 'items',
+            title: 'Granules in this collection',
+            type: 'application/json'
+          }, {
+            href: 'https://cmr.earthdata.nasa.gov/search/concepts/id.html',
+            rel: 'overview',
+            title: 'HTML metadata for collection',
+            type: 'application/json'
+          }, {
+            href: 'https://cmr.earthdata.nasa.gov/search/concepts/id.native',
+            rel: 'metadata',
+            title: 'Native metadata for collection',
+            type: 'application/json'
+          }, {
+            href: 'https://cmr.earthdata.nasa.gov/search/concepts/id.umm_json',
+            rel: 'metadata',
+            title: 'JSON metadata for collection',
+            type: 'application/json'
+          }
+        ],
+        id: 'id',
+        title: 'datasetId' });
+    });
+
+    it('should return null as the temporal extent end time', () => {
+      expect(cmrCollToWFSColl(event, cmrCollTemporal)).toEqual({
+        description: 'summary',
+        extent: {
+          crs: 'http://www.opengis.net/def/crs/OGC/1.3/CRS84',
+          spatial: [
+            -180,
+            -90,
+            180,
+            90
+          ],
+          temporal: [
+            '2009-01-01T00:00:00Z',
+            null
           ],
           trs: 'http://www.opengis.net/def/uom/ISO-8601/0/Gregorian'
         },


### PR DESCRIPTION
## Overview
The issue was, as the title suggests, that the temporal extent for most collections was incorrect. Specifically, the `time_end` field was incorrectly the exact same as the start time. This was due to a line of code in the collections conversion that looked for `time_end` in the CMR collection and set it to `time_start` if it wasn't found. STAC temporal extents must be an array of two datetime strings, which I'm assuming is why the `time_start` was used as the second value.

## Solution
The fix is a rather minor change–– If `time_end` isn't found, the STAC collection will have `null` as the second value in the temporal extent array as per the STAC spec here:
https://github.com/radiantearth/stac-spec/blob/master/collection-spec/collection-spec.md#temporal-extent-object