### PR TITLE
[SCV-22][SCV-26] Validate STAC

### DIFF
--- a/search/lib/api/stac.js
+++ b/search/lib/api/stac.js
@@ -25,10 +25,9 @@ async function getSearch (request, response) {
 
   if (validResult) {
     response.status(200).json(result);
-  } 
-  else {
+  } else {
     response.status(400).json('Bad Request');
-    console.log('json test', response.status(400).json())
+    console.log('json test', response.status(400).json());
   }
 }
 

--- a/search/lib/api/stac.js
+++ b/search/lib/api/stac.js
@@ -21,7 +21,7 @@ async function getSearch (request, response) {
   const event = request.apiGateway.event;
   const params = cmr.convertParams(cmr.STAC_QUERY_PARAMS_CONVERSION_MAP, request.query);
   const result = await search(event, params);
-  
+
   validResult = validateStac(result);
   validResult ? response.status(200).json(result) : response.status(400).json('Bad Request');
 }
@@ -30,7 +30,7 @@ async function postSearch (request, response) {
   logger.info('POST /stac/search');
   const event = request.apiGateway.event;
   const result = await search(event, request.body);
-  
+
   validResult = validateStac(result);
   validResult ? response.status(200).json(result) : response.status(400).json('Bad Request');
 }

--- a/search/lib/api/stac.js
+++ b/search/lib/api/stac.js
@@ -21,27 +21,18 @@ async function getSearch (request, response) {
   const event = request.apiGateway.event;
   const params = cmr.convertParams(cmr.STAC_QUERY_PARAMS_CONVERSION_MAP, request.query);
   const result = await search(event, params);
+  
   validResult = validateStac(result);
-
-  if (validResult) {
-    response.status(200).json(result);
-  } else {
-    response.status(400).json('Bad Request');
-    console.log('json test', response.status(400).json());
-  }
+  validResult ? response.status(200).json(result) : response.status(400).json('Bad Request');
 }
 
 async function postSearch (request, response) {
   logger.info('POST /stac/search');
   const event = request.apiGateway.event;
   const result = await search(event, request.body);
+  
   validResult = validateStac(result);
-
-  if (validResult) {
-    response.status(200).json(result);
-  } else {
-    response.status(400).json('Bad Request');
-  }
+  validResult ? response.status(200).json(result) : response.status(400).json('Bad Request');
 }
 
 function getRootCatalog (request, response) {
@@ -76,12 +67,7 @@ async function getCatalog (request, response) {
   });
 
   validResult = validateStac(catalog);
-
-  if (validResult) {
-    response.status(200).json(catalog);
-  } else {
-    response.status(400).json('Bad Request');
-  }
+  validResult ? response.status(200).json(catalog) : response.status(400).json('Bad Request');
 }
 
 const routes = express.Router();

--- a/search/lib/validator/index.js
+++ b/search/lib/validator/index.js
@@ -38,10 +38,28 @@ function validateSchema (componentName, dataObject, yamlSchemaFile = '../../docs
   return validator(dataObject);
 }
 
+function createStacValidator (stacItem) {
+  if (!stacItem.stac_version || !stacItem.id || !stacItem.description || !stacItem.links) throw Error('Missing required fields');
+}
+
+function validateStac (stacItem) {
+  if (!stacItem) throw new Error('Missing stacItem');
+  try {
+    createStacValidator(stacItem);
+  } catch (e) {
+    console.log(e);
+    return false;
+  }
+
+  return true;
+}
+
 module.exports = {
   loadOpenApiYaml,
   getSchema,
   getSchemaCollection,
   createSchemaValidator,
-  validateSchema
+  validateSchema,
+  createStacValidator,
+  validateStac
 };

--- a/search/lib/validator/index.js
+++ b/search/lib/validator/index.js
@@ -47,7 +47,6 @@ function validateStac (stacItem) {
   try {
     createStacValidator(stacItem);
   } catch (e) {
-    console.log(e);
     return false;
   }
 

--- a/search/lib/validator/index.js
+++ b/search/lib/validator/index.js
@@ -1,64 +1,7 @@
-const fs = require('fs');
-const yaml = require('js-yaml');
-const path = require('path');
-const Ajv = require('ajv');
-const ajv = new Ajv({ allErrors: true });
-
-function loadOpenApiYaml (swaggerYaml) {
-  if (!swaggerYaml) throw new Error('Missing Yaml path');
-  const yamlSchemaFile = path.isAbsolute(swaggerYaml) ? swaggerYaml : path.join(__dirname, swaggerYaml);
-  return yaml.safeLoad(fs.readFileSync(yamlSchemaFile));
-}
-
-function getSchemaCollection (schemaJson) {
-  if (!schemaJson) throw new Error('Missing schema object');
-  if (!schemaJson.components) throw new Error('Missing component collection');
-  if (!schemaJson.components.schemas) throw new Error('Missing collection schemas');
-  return schemaJson.components.schemas;
-}
-
-function getSchema (schemaCollection, schemaComponent) {
-  if (!schemaCollection) throw new Error('Missing schema collection parameter');
-  if (!schemaComponent) throw new Error('Missing schema component name');
-  if (!schemaCollection[schemaComponent]) throw new Error('Component not found in collection');
-  return schemaCollection[schemaComponent];
-}
-
-function createSchemaValidator (schema) {
-  if (!schema) throw new Error('Missing a schema.');
-  return ajv.compile(schema);
-}
-
-function validateSchema (componentName, dataObject, yamlSchemaFile = '../../docs/OAcore+STAC.yaml') {
-  if (!componentName || !dataObject) throw new Error('Missing parameters');
-  const load = loadOpenApiYaml(yamlSchemaFile);
-  const schemaCollection = getSchemaCollection(load);
-  const componentSchema = getSchema(schemaCollection, componentName);
-  const validator = createSchemaValidator(componentSchema);
-  return validator(dataObject);
-}
-
-function createStacValidator (stacItem) {
-  if (!stacItem.stac_version || !stacItem.id || !stacItem.description || !stacItem.links) throw Error('Missing required fields');
-}
-
-function validateStac (stacItem) {
-  if (!stacItem) throw new Error('Missing stacItem');
-  try {
-    createStacValidator(stacItem);
-  } catch (e) {
-    return false;
-  }
-
-  return true;
-}
+const schemaValidator = require('./schemaValidator');
+const stacValidator = require('./stacValidator');
 
 module.exports = {
-  loadOpenApiYaml,
-  getSchema,
-  getSchemaCollection,
-  createSchemaValidator,
-  validateSchema,
-  createStacValidator,
-  validateStac
+  ...schemaValidator,
+  ...stacValidator
 };

--- a/search/lib/validator/schemaValidator.js
+++ b/search/lib/validator/schemaValidator.js
@@ -1,0 +1,47 @@
+const fs = require('fs');
+const yaml = require('js-yaml');
+const path = require('path');
+const Ajv = require('ajv');
+const ajv = new Ajv({ allErrors: true });
+
+function loadOpenApiYaml (swaggerYaml) {
+  if (!swaggerYaml) throw new Error('Missing Yaml path');
+  const yamlSchemaFile = path.isAbsolute(swaggerYaml) ? swaggerYaml : path.join(__dirname, swaggerYaml);
+  return yaml.safeLoad(fs.readFileSync(yamlSchemaFile));
+}
+
+function getSchemaCollection (schemaJson) {
+  if (!schemaJson) throw new Error('Missing schema object');
+  if (!schemaJson.components) throw new Error('Missing component collection');
+  if (!schemaJson.components.schemas) throw new Error('Missing collection schemas');
+  return schemaJson.components.schemas;
+}
+
+function getSchema (schemaCollection, schemaComponent) {
+  if (!schemaCollection) throw new Error('Missing schema collection parameter');
+  if (!schemaComponent) throw new Error('Missing schema component name');
+  if (!schemaCollection[schemaComponent]) throw new Error('Component not found in collection');
+  return schemaCollection[schemaComponent];
+}
+
+function createSchemaValidator (schema) {
+  if (!schema) throw new Error('Missing a schema.');
+  return ajv.compile(schema);
+}
+
+function validateSchema (componentName, dataObject, yamlSchemaFile = '../../docs/OAcore+STAC.yaml') {
+  if (!componentName || !dataObject) throw new Error('Missing parameters');
+  const load = loadOpenApiYaml(yamlSchemaFile);
+  const schemaCollection = getSchemaCollection(load);
+  const componentSchema = getSchema(schemaCollection, componentName);
+  const validator = createSchemaValidator(componentSchema);
+  return validator(dataObject);
+}
+
+module.exports = {
+  loadOpenApiYaml,
+  getSchema,
+  getSchemaCollection,
+  createSchemaValidator,
+  validateSchema
+};

--- a/search/lib/validator/stacValidator.js
+++ b/search/lib/validator/stacValidator.js
@@ -1,0 +1,19 @@
+function createStacValidator (stacItem) {
+  if (!stacItem.stac_version || !stacItem.id || !stacItem.description || !stacItem.links) throw Error('Missing required fields');
+}
+
+function validateStac (stacItem) {
+  if (!stacItem) throw new Error('Missing stacItem');
+  try {
+    createStacValidator(stacItem);
+  } catch (e) {
+    return false;
+  }
+
+  return true;
+}
+
+module.exports = {
+  createStacValidator,
+  validateStac
+};

--- a/search/lib/validator/stacValidator.js
+++ b/search/lib/validator/stacValidator.js
@@ -1,11 +1,10 @@
-function createStacValidator (stacItem) {
-  if (!stacItem.stac_version || !stacItem.id || !stacItem.description || !stacItem.links) throw Error('Missing required fields');
-}
 
 function validateStac (stacItem) {
   if (!stacItem) throw new Error('Missing stacItem');
   try {
-    createStacValidator(stacItem);
+    if (!stacItem.stac_version || !stacItem.id || !stacItem.description || !stacItem.links) {
+    throw Error('Missing required fields');
+    }
   } catch (e) {
     return false;
   }
@@ -14,6 +13,6 @@ function validateStac (stacItem) {
 }
 
 module.exports = {
-  createStacValidator,
+  // createStacValidator,
   validateStac
 };

--- a/search/lib/validator/stacValidator.js
+++ b/search/lib/validator/stacValidator.js
@@ -3,7 +3,7 @@ function validateStac (stacItem) {
   if (!stacItem) throw new Error('Missing stacItem');
   try {
     if (!stacItem.stac_version || !stacItem.id || !stacItem.description || !stacItem.links) {
-    throw Error('Missing required fields');
+      throw Error('Missing required fields');
     }
   } catch (e) {
     return false;
@@ -13,6 +13,5 @@ function validateStac (stacItem) {
 }
 
 module.exports = {
-  // createStacValidator,
   validateStac
 };

--- a/search/package-lock.json
+++ b/search/package-lock.json
@@ -4663,10 +4663,12 @@
     },
     "fsevents": {
       "version": "1.2.9",
-      "resolved": "",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.9.tgz",
+      "integrity": "sha512-oeyj2H3EjjonWcFjD5NvZNE9Rqe4UW+nQBU2HNeKw0koVLEFIhtyETyAakeAM3de7Z/SW5kcA+fZUait9EApnw==",
       "dev": true,
       "optional": true,
       "requires": {
+        "nan": "^2.12.1",
         "node-pre-gyp": "^0.12.0"
       },
       "dependencies": {
@@ -9654,6 +9656,13 @@
       "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
       "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
       "dev": true
+    },
+    "nan": {
+      "version": "2.14.1",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.1.tgz",
+      "integrity": "sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw==",
+      "dev": true,
+      "optional": true
     },
     "nanomatch": {
       "version": "1.2.13",

--- a/search/tests/api/stac.spec.js
+++ b/search/tests/api/stac.spec.js
@@ -6,7 +6,7 @@ const { mockFunction, revertFunction, logger } = require('../util');
 
 describe('getSearch', () => {
   it('should return a set of collections that match a simple query', async () => {
-    const request = { apiGateway: { event: {} }, app: { logger: logger } };
+    const request = { apiGateway: {}, app: { logger: logger } };
     const response = {
       status: jest.fn().mockReturnThis(),
       json: jest.fn()

--- a/search/tests/validator/schemaValidator.spec.js
+++ b/search/tests/validator/schemaValidator.spec.js
@@ -4,7 +4,7 @@ const {
   loadOpenApiYaml,
   getSchema,
   getSchemaCollection,
-  validateSchema,
+  validateSchema
 } = require('../../lib/validator');
 
 describe('createSchemaValidator', () => {

--- a/search/tests/validator/schemaValidator.spec.js
+++ b/search/tests/validator/schemaValidator.spec.js
@@ -5,8 +5,6 @@ const {
   getSchema,
   getSchemaCollection,
   validateSchema,
-  createStacValidator,
-  validateStac
 } = require('../../lib/validator');
 
 describe('createSchemaValidator', () => {
@@ -199,51 +197,5 @@ describe('validateSchema', () => {
 
   it('should validate the test object against the schema for the given component', () => {
     expect(validateSchema('bbox', testBbox)).toEqual(true);
-  });
-});
-
-describe('createStacValidator', () => {
-  it('should exist', () => {
-    expect(createStacValidator).toBeDefined();
-  });
-
-  it('should take in a stacItem as a parameter', () => {
-    expect(() => createStacValidator()).toThrow();
-  });
-});
-
-describe('validateStac', () => {
-  const validStacFeature = {
-    stac_version: '0.8.0',
-    id: '1',
-    description: 'description',
-    links: []
-  };
-
-  const invalidStacFeature = {
-    stac_version: '0.8.0',
-    id: '1',
-    description: '',
-    links: []
-  };
-
-  it('should exist', () => {
-    expect(validateStac).toBeDefined();
-  });
-
-  it('should take in a stacItem as a parameter', () => {
-    expect(() => validateStac()).toThrow();
-  });
-
-  it('should take in a stacItem and return a boolean', () => {
-    expect(typeof validateStac(validStacFeature)).toEqual('boolean');
-  });
-
-  it('should check for required fields', () => {
-    expect(validateStac(invalidStacFeature)).toEqual(false);
-  });
-
-  it('should validate a stacItem with required fields', () => {
-    expect(validateStac(validStacFeature)).toEqual(true);
   });
 });

--- a/search/tests/validator/stacValidator.spec.js
+++ b/search/tests/validator/stacValidator.spec.js
@@ -1,0 +1,41 @@
+const { validateStac } = require('../../lib/validator');
+
+describe('stacValidator', () => {
+  
+  describe('validateStac', () => {
+    const validStacFeature = {
+      stac_version: '0.8.0',
+      id: '1',
+      description: 'description',
+      links: []
+    };
+  
+    const invalidStacFeature = {
+      stac_version: '0.8.0',
+      id: '1',
+      description: '',
+      links: []
+    };
+  
+    it('should exist', () => {
+      expect(validateStac).toBeDefined();
+    });
+  
+    it('should take in a stacItem as a parameter', () => {
+      expect(() => validateStac()).toThrow();
+    });
+  
+    it('should take in a stacItem and return a boolean', () => {
+      expect(typeof validateStac(validStacFeature)).toEqual('boolean');
+    });
+  
+    it('should check for required fields', () => {
+      expect(validateStac(invalidStacFeature)).toEqual(false);
+    });
+  
+    it('should validate a stacItem with required fields', () => {
+      expect(validateStac(validStacFeature)).toEqual(true);
+    });
+  });
+
+})

--- a/search/tests/validator/stacValidator.spec.js
+++ b/search/tests/validator/stacValidator.spec.js
@@ -1,7 +1,6 @@
 const { validateStac } = require('../../lib/validator');
 
 describe('stacValidator', () => {
-  
   describe('validateStac', () => {
     const validStacFeature = {
       stac_version: '0.8.0',
@@ -9,33 +8,32 @@ describe('stacValidator', () => {
       description: 'description',
       links: []
     };
-  
+
     const invalidStacFeature = {
       stac_version: '0.8.0',
       id: '1',
       description: '',
       links: []
     };
-  
+
     it('should exist', () => {
       expect(validateStac).toBeDefined();
     });
-  
+
     it('should take in a stacItem as a parameter', () => {
       expect(() => validateStac()).toThrow();
     });
-  
+
     it('should take in a stacItem and return a boolean', () => {
       expect(typeof validateStac(validStacFeature)).toEqual('boolean');
     });
-  
+
     it('should check for required fields', () => {
       expect(validateStac(invalidStacFeature)).toEqual(false);
     });
-  
+
     it('should validate a stacItem with required fields', () => {
       expect(validateStac(validStacFeature)).toEqual(true);
     });
   });
-
-})
+});

--- a/search/tests/validator/validator.spec.js
+++ b/search/tests/validator/validator.spec.js
@@ -4,7 +4,9 @@ const {
   loadOpenApiYaml,
   getSchema,
   getSchemaCollection,
-  validateSchema
+  validateSchema,
+  createStacValidator,
+  validateStac
 } = require('../../lib/validator');
 
 describe('createSchemaValidator', () => {
@@ -197,5 +199,51 @@ describe('validateSchema', () => {
 
   it('should validate the test object against the schema for the given component', () => {
     expect(validateSchema('bbox', testBbox)).toEqual(true);
+  });
+});
+
+describe('createStacValidator', () => {
+  it('should exist', () => {
+    expect(createStacValidator).toBeDefined();
+  });
+
+  it('should take in a stacItem as a parameter', () => {
+    expect(() => createStacValidator()).toThrow();
+  });
+});
+
+describe('validateStac', () => {
+  const validStacFeature = {
+    stac_version: '0.8.0',
+    id: '1',
+    description: 'description',
+    links: []
+  };
+
+  const invalidStacFeature = {
+    stac_version: '0.8.0',
+    id: '1',
+    description: '',
+    links: []
+  };
+
+  it('should exist', () => {
+    expect(validateStac).toBeDefined();
+  });
+
+  it('should take in a stacItem as a parameter', () => {
+    expect(() => validateStac()).toThrow();
+  });
+
+  it('should take in a stacItem and return a boolean', () => {
+    expect(typeof validateStac(validStacFeature)).toEqual('boolean');
+  });
+
+  it('should check for required fields', () => {
+    expect(validateStac(invalidStacFeature)).toEqual(false);
+  });
+
+  it('should validate a stacItem with required fields', () => {
+    expect(validateStac(validStacFeature)).toEqual(true);
   });
 });


### PR DESCRIPTION
These tickets brought together two goals, validate stac items, and return 400 on invalid items. In the past, you could search for invalid collections and providers that didn't exist and get a "bare-bones" stac collection. There was also an issue with features that missed some required data coming in as well.

My solution was to add functions to the validator that would validate stac items. I ultimately ended up splitting the schema validator functions and stac validator functions into two files and exporting them through `index.js` after a suggestion from @DrewE84. I also created a test for the new functions. In addition to this, I responded to invalid stac search items returning `400` responses.