### PR TITLE
[SCV-27][SCV-28] Replace ID with Short Name

### DIFF
--- a/search/lib/convert/collections.js
+++ b/search/lib/convert/collections.js
@@ -56,19 +56,19 @@ function createExtent (cmrCollection) {
 
 function createLinks (event, cmrCollection) {
   return [
-    wfs.createLink('self', generateAppUrl(event, `/collections/${cmrCollection.id}`),
+    wfs.createLink('self', generateAppUrl(event, `/collections/${cmrCollection.short_name}`),
       'Info about this collection'),
-    wfs.createLink('stac', stacSearchWithCurrentParams(event, cmrCollection.id),
+    wfs.createLink('stac', stacSearchWithCurrentParams(event, cmrCollection.short_name),
       'STAC Search this collection'),
-    wfs.createLink('cmr', cmrGranuleSearchWithCurrentParams(event, cmrCollection.id),
+    wfs.createLink('cmr', cmrGranuleSearchWithCurrentParams(event, cmrCollection.short_name),
       'CMR Search this collection'),
-    wfs.createLink('items', generateAppUrl(event, `/collections/${cmrCollection.id}/items`),
+    wfs.createLink('items', generateAppUrl(event, `/collections/${cmrCollection.short_name}/items`),
       'Granules in this collection'),
-    wfs.createLink('overview', cmr.makeCmrSearchUrl(`/concepts/${cmrCollection.id}.html`),
+    wfs.createLink('overview', cmr.makeCmrSearchUrl(`/concepts/${cmrCollection.short_name}.html`),
       'HTML metadata for collection'),
-    wfs.createLink('metadata', cmr.makeCmrSearchUrl(`/concepts/${cmrCollection.id}.native`),
+    wfs.createLink('metadata', cmr.makeCmrSearchUrl(`/concepts/${cmrCollection.short_name}.native`),
       'Native metadata for collection'),
-    wfs.createLink('metadata', cmr.makeCmrSearchUrl(`/concepts/${cmrCollection.id}.umm_json`),
+    wfs.createLink('metadata', cmr.makeCmrSearchUrl(`/concepts/${cmrCollection.short_name}.umm_json`),
       'JSON metadata for collection')
   ];
 }
@@ -76,7 +76,7 @@ function createLinks (event, cmrCollection) {
 function cmrCollToWFSColl (event, cmrCollection) {
   if (!cmrCollection) return null;
   return {
-    id: cmrCollection.id,
+    id: cmrCollection.short_name,
     title: cmrCollection.dataset_id,
     description: cmrCollection.summary,
     links: createLinks(event, cmrCollection),

--- a/search/lib/convert/granules.js
+++ b/search/lib/convert/granules.js
@@ -111,11 +111,11 @@ function cmrGranToFeatureGeoJSON (event, cmrGran) {
     assets.opendap = linkToAsset(opendapLink);
   }
 
-  assets.metadata = wfs.createAssetLink(cmr.makeCmrSearchUrl(`/concepts/${cmrGran.short_name}.native`));
+  assets.metadata = wfs.createAssetLink(cmr.makeCmrSearchUrl(`/concepts/${cmrGran.id}.native`));
 
   return {
     type: 'Feature',
-    id: cmrGran.short_name,
+    id: cmrGran.id,
     collection: cmrGran.collection_concept_id,
     geometry: cmrSpatialToGeoJSONGeometry(cmrGran),
     bbox: cmrGran.bounding_box,
@@ -123,7 +123,7 @@ function cmrGranToFeatureGeoJSON (event, cmrGran) {
       {
         rel: 'self',
         href: generateAppUrl(event,
-          `/collections/${cmrGran.collection_concept_id}/items/${cmrGran.short_name}`)
+          `/collections/${cmrGran.collection_concept_id}/items/${cmrGran.id}`)
       },
       {
         rel: 'parent',

--- a/search/lib/convert/granules.js
+++ b/search/lib/convert/granules.js
@@ -115,7 +115,7 @@ function cmrGranToFeatureGeoJSON (event, cmrGran) {
 
   return {
     type: 'Feature',
-    id: cmrGran.id,
+    id: cmrGran.producer_granule_id,
     collection: cmrGran.collection_concept_id,
     geometry: cmrSpatialToGeoJSONGeometry(cmrGran),
     bbox: cmrGran.bounding_box,
@@ -123,7 +123,7 @@ function cmrGranToFeatureGeoJSON (event, cmrGran) {
       {
         rel: 'self',
         href: generateAppUrl(event,
-          `/collections/${cmrGran.collection_concept_id}/items/${cmrGran.id}`)
+          `/collections/${cmrGran.collection_concept_id}/items/${cmrGran.producer_granule_id}`)
       },
       {
         rel: 'parent',

--- a/search/lib/convert/granules.js
+++ b/search/lib/convert/granules.js
@@ -56,16 +56,9 @@ const BROWSE_REL = 'http://esipfed.org/ns/fedsearch/1.1/browse#';
 const DOC_REL = 'http://esipfed.org/ns/fedsearch/1.1/documentation#';
 
 function cmrGranToFeatureGeoJSON (event, cmrGran) {
-  // eslint-disable-next-line camelcase
   const datetime = cmrGran.time_start.toString();
-  // eslint-disable-next-line camelcase
-  const start_datetime = cmrGran.time_start.toString();
-  // eslint-disable-next-line camelcase
-  let end_datetime = cmrGran.time_start.toString();
-  if (cmrGran.time_end) {
-    // eslint-disable-next-line camelcase
-    end_datetime = cmrGran.time_end.toString();
-  }
+  const startDatetime = cmrGran.time_start.toString();
+  const endDatetime = cmrGran.time_end ? cmrGran.time_end.toString() : cmrGran.time_start.toString();
 
   const dataLink = _.first(
     cmrGran.links.filter(l => l.rel === DATA_REL && !l.inherited)
@@ -82,13 +75,13 @@ function cmrGranToFeatureGeoJSON (event, cmrGran) {
       return {
         href: l.href,
         type: l.type
-      }
+      };
     } else {
       return {
         name: l.title,
         href: l.href,
         type: l.type
-      }
+      };
     }
   };
 
@@ -118,11 +111,11 @@ function cmrGranToFeatureGeoJSON (event, cmrGran) {
     assets.opendap = linkToAsset(opendapLink);
   }
 
-  assets.metadata = wfs.createAssetLink(cmr.makeCmrSearchUrl(`/concepts/${cmrGran.id}.native`));
+  assets.metadata = wfs.createAssetLink(cmr.makeCmrSearchUrl(`/concepts/${cmrGran.short_name}.native`));
 
   return {
     type: 'Feature',
-    id: cmrGran.id,
+    id: cmrGran.short_name,
     collection: cmrGran.collection_concept_id,
     geometry: cmrSpatialToGeoJSONGeometry(cmrGran),
     bbox: cmrGran.bounding_box,
@@ -130,7 +123,7 @@ function cmrGranToFeatureGeoJSON (event, cmrGran) {
       {
         rel: 'self',
         href: generateAppUrl(event,
-          `/collections/${cmrGran.collection_concept_id}/items/${cmrGran.id}`)
+          `/collections/${cmrGran.collection_concept_id}/items/${cmrGran.short_name}`)
       },
       {
         rel: 'parent',
@@ -150,8 +143,8 @@ function cmrGranToFeatureGeoJSON (event, cmrGran) {
     ],
     properties: {
       datetime,
-      start_datetime,
-      end_datetime
+      start_datetime: startDatetime,
+      end_datetime: endDatetime
     },
     assets
   };

--- a/search/serverless-offline.yml
+++ b/search/serverless-offline.yml
@@ -20,6 +20,7 @@ functions:
       LOG_LEVEL: info
       LOG_DISABLED: false
       STAC_VERSION: 0.8.0
+      CMR_STAC_RELATIVE_ROOT_URL: /stac
 
 plugins:
   - serverless-offline

--- a/search/tests/convert/collections.spec.js
+++ b/search/tests/convert/collections.spec.js
@@ -96,6 +96,7 @@ describe('collections', () => {
   describe('cmrCollToWFSCol', () => {
     const cmrColl = {
       id: 'id',
+      short_name: 'LAADS',
       dataset_id: 'datasetId',
       summary: 'summary',
       time_start: '0',
@@ -104,6 +105,7 @@ describe('collections', () => {
 
     const cmrCollTemporal = {
       id: 'id',
+      short_name: 'LAADS',
       dataset_id: 'datasetId',
       summary: 'summary',
       time_start: '2009-01-01T00:00:00Z'
@@ -130,43 +132,43 @@ describe('collections', () => {
         },
         links: [
           {
-            href: 'http://example.com/cmr-stac/collections/id',
+            href: 'http://example.com/cmr-stac/collections/LAADS',
             rel: 'self',
             title: 'Info about this collection',
             type: 'application/json'
           }, {
-            href: 'http://example.com/cmr-stac/stac/search?collectionId=id',
+            href: 'http://example.com/cmr-stac/stac/search?collectionId=LAADS',
             rel: 'stac',
             title: 'STAC Search this collection',
             type: 'application/json'
           }, {
-            href: 'https://cmr.earthdata.nasa.gov/search/granules.json?collection_concept_id=id',
+            href: 'https://cmr.earthdata.nasa.gov/search/granules.json?collection_concept_id=LAADS',
             rel: 'cmr',
             title: 'CMR Search this collection',
             type: 'application/json'
           }, {
-            href: 'http://example.com/cmr-stac/collections/id/items',
+            href: 'http://example.com/cmr-stac/collections/LAADS/items',
             rel: 'items',
             title: 'Granules in this collection',
             type: 'application/json'
           }, {
-            href: 'https://cmr.earthdata.nasa.gov/search/concepts/id.html',
+            href: 'https://cmr.earthdata.nasa.gov/search/concepts/LAADS.html',
             rel: 'overview',
             title: 'HTML metadata for collection',
             type: 'text/html'
           }, {
-            href: 'https://cmr.earthdata.nasa.gov/search/concepts/id.xml',
+            href: 'https://cmr.earthdata.nasa.gov/search/concepts/LAADS.xml',
             rel: 'metadata',
             title: 'Native metadata for collection',
             type: 'application/xml'
           }, {
-            href: 'https://cmr.earthdata.nasa.gov/search/concepts/id.umm_json',
+            href: 'https://cmr.earthdata.nasa.gov/search/concepts/LAADS.umm_json',
             rel: 'metadata',
             title: 'JSON metadata for collection',
             type: 'application/json'
           }
         ],
-        id: 'id',
+        id: 'LAADS',
         title: 'datasetId' });
     });
 
@@ -189,43 +191,43 @@ describe('collections', () => {
         },
         links: [
           {
-            href: 'http://example.com/cmr-stac/collections/id',
+            href: 'http://example.com/cmr-stac/collections/LAADS',
             rel: 'self',
             title: 'Info about this collection',
             type: 'application/json'
           }, {
-            href: 'http://example.com/cmr-stac/stac/search?collectionId=id',
+            href: 'http://example.com/cmr-stac/stac/search?collectionId=LAADS',
             rel: 'stac',
             title: 'STAC Search this collection',
             type: 'application/json'
           }, {
-            href: 'https://cmr.earthdata.nasa.gov/search/granules.json?collection_concept_id=id',
+            href: 'https://cmr.earthdata.nasa.gov/search/granules.json?collection_concept_id=LAADS',
             rel: 'cmr',
             title: 'CMR Search this collection',
             type: 'application/json'
           }, {
-            href: 'http://example.com/cmr-stac/collections/id/items',
+            href: 'http://example.com/cmr-stac/collections/LAADS/items',
             rel: 'items',
             title: 'Granules in this collection',
             type: 'application/json'
           }, {
-            href: 'https://cmr.earthdata.nasa.gov/search/concepts/id.html',
+            href: 'https://cmr.earthdata.nasa.gov/search/concepts/LAADS.html',
             rel: 'overview',
             title: 'HTML metadata for collection',
             type: 'text/html'
           }, {
-            href: 'https://cmr.earthdata.nasa.gov/search/concepts/id.xml',
+            href: 'https://cmr.earthdata.nasa.gov/search/concepts/LAADS.xml',
             rel: 'metadata',
             title: 'Native metadata for collection',
             type: 'application/xml'
           }, {
-            href: 'https://cmr.earthdata.nasa.gov/search/concepts/id.umm_json',
+            href: 'https://cmr.earthdata.nasa.gov/search/concepts/LAADS.umm_json',
             rel: 'metadata',
             title: 'JSON metadata for collection',
             type: 'application/json'
           }
         ],
-        id: 'id',
+        id: 'LAADS',
         title: 'datasetId' });
     });
   });

--- a/search/tests/convert/granules.spec.js
+++ b/search/tests/convert/granules.spec.js
@@ -154,6 +154,7 @@ describe('granuleToItem', () => {
   describe('cmrGranToFeatureGeoJSON', () => {
     const cmrGran = {
       id: 1,
+      short_name: 'LAADS',
       collection_concept_id: 10,
       bbox: [90, -180, -90, 180],
       dataset_id: 'datasetId',
@@ -183,7 +184,7 @@ describe('granuleToItem', () => {
     it('should return a FeatureGeoJSON from a cmrGran', () => {
       expect(cmrGranToFeatureGeoJSON(event, cmrGran)).toEqual({
         type: 'Feature',
-        id: 1,
+        id: 'LAADS',
         bbox: undefined,
         collection: 10,
         geometry: { type: 'Point', coordinates: [77, 39] },
@@ -198,14 +199,14 @@ describe('granuleToItem', () => {
             type: 'images/jpeg'
           },
           metadata: {
-            href: 'https://cmr.earthdata.nasa.gov/search/concepts/1.xml',
+            href: 'https://cmr.earthdata.nasa.gov/search/concepts/LAADS.xml',
             type: 'application/xml'
           }
         },
         links: [
           {
             rel: 'self',
-            href: 'http://example.com/cmr-stac/collections/10/items/1'
+            href: 'http://example.com/cmr-stac/collections/10/items/LAADS'
           },
           {
             rel: 'parent',
@@ -230,6 +231,7 @@ describe('granuleToItem', () => {
   describe('cmrGranulesToFeatureCollection', () => {
     const cmrGran = [{
       id: 1,
+      short_name: 'LAADS',
       collection_concept_id: 10,
       dataset_id: 'datasetId',
       summary: 'summary',
@@ -253,7 +255,7 @@ describe('granuleToItem', () => {
       expect(cmrGranulesToFeatureCollection(event, cmrGran)).toEqual({
         type: 'FeatureCollection',
         features: [{
-          id: 1,
+          id: 'LAADS',
           collection: 10,
           geometry: { type: 'Point', coordinates: [77, 39] },
           bbox: undefined,
@@ -265,14 +267,14 @@ describe('granuleToItem', () => {
           type: 'Feature',
           assets: {
             metadata: {
-              href: 'https://cmr.earthdata.nasa.gov/search/concepts/1.xml',
+              href: 'https://cmr.earthdata.nasa.gov/search/concepts/LAADS.xml',
               type: 'application/xml'
             }
           },
           links: [
             {
               rel: 'self',
-              href: 'http://example.com/cmr-stac/collections/10/items/1'
+              href: 'http://example.com/cmr-stac/collections/10/items/LAADS'
             },
             {
               rel: 'parent',

--- a/search/tests/convert/granules.spec.js
+++ b/search/tests/convert/granules.spec.js
@@ -154,7 +154,6 @@ describe('granuleToItem', () => {
   describe('cmrGranToFeatureGeoJSON', () => {
     const cmrGran = {
       id: 1,
-      short_name: 'LAADS',
       collection_concept_id: 10,
       bbox: [90, -180, -90, 180],
       dataset_id: 'datasetId',
@@ -184,7 +183,7 @@ describe('granuleToItem', () => {
     it('should return a FeatureGeoJSON from a cmrGran', () => {
       expect(cmrGranToFeatureGeoJSON(event, cmrGran)).toEqual({
         type: 'Feature',
-        id: 'LAADS',
+        id: 1,
         bbox: undefined,
         collection: 10,
         geometry: { type: 'Point', coordinates: [77, 39] },
@@ -199,14 +198,14 @@ describe('granuleToItem', () => {
             type: 'images/jpeg'
           },
           metadata: {
-            href: 'https://cmr.earthdata.nasa.gov/search/concepts/LAADS.xml',
+            href: 'https://cmr.earthdata.nasa.gov/search/concepts/1.xml',
             type: 'application/xml'
           }
         },
         links: [
           {
             rel: 'self',
-            href: 'http://example.com/cmr-stac/collections/10/items/LAADS'
+            href: 'http://example.com/cmr-stac/collections/10/items/1'
           },
           {
             rel: 'parent',
@@ -231,7 +230,6 @@ describe('granuleToItem', () => {
   describe('cmrGranulesToFeatureCollection', () => {
     const cmrGran = [{
       id: 1,
-      short_name: 'LAADS',
       collection_concept_id: 10,
       dataset_id: 'datasetId',
       summary: 'summary',
@@ -255,7 +253,7 @@ describe('granuleToItem', () => {
       expect(cmrGranulesToFeatureCollection(event, cmrGran)).toEqual({
         type: 'FeatureCollection',
         features: [{
-          id: 'LAADS',
+          id: 1,
           collection: 10,
           geometry: { type: 'Point', coordinates: [77, 39] },
           bbox: undefined,
@@ -267,14 +265,14 @@ describe('granuleToItem', () => {
           type: 'Feature',
           assets: {
             metadata: {
-              href: 'https://cmr.earthdata.nasa.gov/search/concepts/LAADS.xml',
+              href: 'https://cmr.earthdata.nasa.gov/search/concepts/1.xml',
               type: 'application/xml'
             }
           },
           links: [
             {
               rel: 'self',
-              href: 'http://example.com/cmr-stac/collections/10/items/LAADS'
+              href: 'http://example.com/cmr-stac/collections/10/items/1'
             },
             {
               rel: 'parent',

--- a/search/tests/convert/granules.spec.js
+++ b/search/tests/convert/granules.spec.js
@@ -154,6 +154,7 @@ describe('granuleToItem', () => {
   describe('cmrGranToFeatureGeoJSON', () => {
     const cmrGran = {
       id: 1,
+      producer_granule_id: 'AST_L1A#00310102016013836_10112016120846.hdf',
       collection_concept_id: 10,
       bbox: [90, -180, -90, 180],
       dataset_id: 'datasetId',
@@ -183,7 +184,7 @@ describe('granuleToItem', () => {
     it('should return a FeatureGeoJSON from a cmrGran', () => {
       expect(cmrGranToFeatureGeoJSON(event, cmrGran)).toEqual({
         type: 'Feature',
-        id: 1,
+        id: 'AST_L1A#00310102016013836_10112016120846.hdf',
         bbox: undefined,
         collection: 10,
         geometry: { type: 'Point', coordinates: [77, 39] },
@@ -205,7 +206,7 @@ describe('granuleToItem', () => {
         links: [
           {
             rel: 'self',
-            href: 'http://example.com/cmr-stac/collections/10/items/1'
+            href: 'http://example.com/cmr-stac/collections/10/items/AST_L1A#00310102016013836_10112016120846.hdf'
           },
           {
             rel: 'parent',
@@ -230,6 +231,7 @@ describe('granuleToItem', () => {
   describe('cmrGranulesToFeatureCollection', () => {
     const cmrGran = [{
       id: 1,
+      producer_granule_id: 'AST_L1A#00310102016013836_10112016120846.hdf',
       collection_concept_id: 10,
       dataset_id: 'datasetId',
       summary: 'summary',
@@ -253,7 +255,7 @@ describe('granuleToItem', () => {
       expect(cmrGranulesToFeatureCollection(event, cmrGran)).toEqual({
         type: 'FeatureCollection',
         features: [{
-          id: 1,
+          id: 'AST_L1A#00310102016013836_10112016120846.hdf',
           collection: 10,
           geometry: { type: 'Point', coordinates: [77, 39] },
           bbox: undefined,
@@ -272,7 +274,7 @@ describe('granuleToItem', () => {
           links: [
             {
               rel: 'self',
-              href: 'http://example.com/cmr-stac/collections/10/items/1'
+              href: 'http://example.com/cmr-stac/collections/10/items/AST_L1A#00310102016013836_10112016120846.hdf'
             },
             {
               rel: 'parent',


### PR DESCRIPTION
## Overview
This branch replaces collection IDs with the more readable and usable `short_name` field, and granule IDs with the `producer_granule_id`. These are implemented in the conversion of CMR granules and collections to STAC collections and items.