### PR TITLE
[SCV-55] Spatial Extent for Collections Fixed

### DIFF
--- a/search/lib/convert/bounding-box.js
+++ b/search/lib/convert/bounding-box.js
@@ -40,10 +40,18 @@ function pointStringToPoints (pointStr) {
   return chunk(parseOrdinateString(pointStr), 2);
 }
 
+function reorderBoxValues (cmrBox) {
+  if (!cmrBox) {
+    throw new Error('Missing arguments');
+  }
+  return [cmrBox[1], cmrBox[0], cmrBox[3], cmrBox[2]];
+}
+
 module.exports = {
   addPointsToBbox,
   mergeBoxes,
   parseOrdinateString,
   pointStringToPoints,
+  reorderBoxValues,
   WHOLE_WORLD_BBOX
 };

--- a/search/lib/convert/collections.js
+++ b/search/lib/convert/collections.js
@@ -1,6 +1,6 @@
 const cmr = require('../cmr');
 const { wfs, generateAppUrl } = require('../util');
-const { WHOLE_WORLD_BBOX, pointStringToPoints, parseOrdinateString, addPointsToBbox, mergeBoxes } = require('./bounding-box');
+const { WHOLE_WORLD_BBOX, pointStringToPoints, parseOrdinateString, addPointsToBbox, mergeBoxes, reorderBoxValues } = require('./bounding-box');
 
 function cmrCollSpatialToExtents (cmrColl) {
   let bbox = null;
@@ -18,7 +18,8 @@ function cmrCollSpatialToExtents (cmrColl) {
     throw new Error(`Unexpected spatial extent of lines in ${cmrColl.id}`);
   }
   if (cmrColl.boxes) {
-    bbox = cmrColl.boxes.reduce((box, boxStr) => mergeBoxes(box, parseOrdinateString(boxStr)), bbox);
+    const mergedBox = cmrColl.boxes.reduce((box, boxStr) => mergeBoxes(box, parseOrdinateString(boxStr)), bbox);
+    bbox = reorderBoxValues(mergedBox);
   }
   if (bbox === null) {
     // whole world bbox

--- a/search/lib/convert/granules.js
+++ b/search/lib/convert/granules.js
@@ -82,13 +82,13 @@ function cmrGranToFeatureGeoJSON (event, cmrGran) {
       return {
         href: l.href,
         type: l.type
-      }
+      };
     } else {
       return {
         name: l.title,
         href: l.href,
         type: l.type
-      }
+      };
     }
   };
 

--- a/search/tests/convert/bounding-box.spec.js
+++ b/search/tests/convert/bounding-box.spec.js
@@ -1,4 +1,4 @@
-const { addPointsToBbox, mergeBoxes } = require('../../lib/convert/bounding-box');
+const { addPointsToBbox, mergeBoxes, reorderBoxValues } = require('../../lib/convert/bounding-box');
 
 describe('bbox', () => {
   const testBbox = [-10, -10, 10, 10];
@@ -6,6 +6,18 @@ describe('bbox', () => {
   const points = [[100, 20], [5, -5]];
   const lotsOfPoints = [[100, 20], [5, -5], [-40, 73]];
   const WHOLE_WORLD_BBOX = [-180, -90, 180, 90];
+
+  describe('reorderBoxValues', () => {
+    const cmrWorldBox = [-90, -180, 90, 180];
+
+    it('should require one argument', () => {
+      expect(() => reorderBoxValues()).toThrow(Error);
+    });
+
+    it('should reorder the box values to be [minLon, minLat, maxLon, maxLat]', () => {
+      expect(reorderBoxValues(cmrWorldBox)).toEqual(WHOLE_WORLD_BBOX);
+    });
+  });
 
   describe('addPointsToBbox', () => {
     it('should create the largest bbox', () => {

--- a/search/tests/convert/collections.spec.js
+++ b/search/tests/convert/collections.spec.js
@@ -12,16 +12,16 @@ describe('collections', () => {
 
     it('should return a bounding box from given polygon', () => {
       cmrCollection = {
-        polygons: [['30 -10 70 33 -45 66']]
+        polygons: [['30 -10 70 33 -145 66']]
       };
-      expect(cmrCollSpatialToExtents(cmrCollection)).toEqual([-45, -10, 70, 66]);
+      expect(cmrCollSpatialToExtents(cmrCollection)).toEqual([-145, -10, 70, 66]);
     });
 
     it('should return a bounding box from given points', () => {
       cmrCollection = {
-        points: ['30 -10', '70 33', '-45 66']
+        points: ['30 -10', '70 33', '-145 66']
       };
-      expect(cmrCollSpatialToExtents(cmrCollection)).toEqual([-45, -10, 70, 66]);
+      expect(cmrCollSpatialToExtents(cmrCollection)).toEqual([-145, -10, 70, 66]);
     });
 
     it('should throw an error if given lines', () => {
@@ -34,9 +34,16 @@ describe('collections', () => {
 
     it('should return a bounding box from provided coordinates [west north east south]', () => {
       cmrCollection = {
-        boxes: ['-23.4 -74.6 54.9 33.3']
+        boxes: ['-74.6 -123.4 33.3 54.9 ']
       };
-      expect(cmrCollSpatialToExtents(cmrCollection)).toEqual([-23.4, -74.6, 54.9, 33.3]);
+      expect(cmrCollSpatialToExtents(cmrCollection)).toEqual([-123.4, -74.6, 54.9, 33.3]);
+    });
+
+    it('should reorder values to fit stac spec [west north east south]', () => {
+      cmrCollection = {
+        boxes: ['-90 -180 90 180']
+      };
+      expect(cmrCollSpatialToExtents(cmrCollection)).toEqual([-180, -90, 180, 90]);
     });
 
     it('should return a bounding box containing the WHOLE_WORLD_BBOX', () => {


### PR DESCRIPTION
## Overview
This branch fixes the spatial extent bug that made its way to UAT. 

## The Problem
Essentially, the ordering of the Bounding Boxes was incorrect after converting a CMR collection to a STAC collection. CMR `boxes` are stored in the order `[minLat, minLon, maxLat, maxLon]`, where STAC `bbox` values are ordered `[minLon, minLat, maxLon, maxLat]`. This was only happening when converting CMR boxes, but not polygons or points.

## The Solution
I added a simple function to `convert/bounding-box.js` called `reorderBoxValues()`. The functionality that was already in the bbox conversion was working well, and could handle merging multiple CMR `boxes` into a single STAC `bbox`. So `reorderBoxValues()` takes that output and reorders it to fit the STAC specifications.
I added tests to both `reorderBoxValues()` and `cmrCollSpatialToExtents()` to double check that the output values were in the right order. I also tweeked some of the other spatial conversion tests for polygon and points to ensure that the correct value order was being returned.