### PR TITLE
[SCV-68] MIME Image Label

### DIFF
--- a/search/lib/convert/granules.js
+++ b/search/lib/convert/granules.js
@@ -93,18 +93,18 @@ function cmrGranToFeatureGeoJSON (event, cmrGran) {
     assets.browse = linkToAsset(browseLink);
 
     if (browseLink.href.includes('.png')) {
-      assets.browse.type = 'images/png';
+      assets.browse.type = 'image/png';
     }
     if (browseLink.href.includes('.tiff')) {
-      assets.browse.type = 'images/tiff';
+      assets.browse.type = 'image/tiff';
     }
     if (browseLink.href.includes('.tif')) {
-      assets.browse.type = 'images/tiff';
+      assets.browse.type = 'image/tiff';
     }
     if (browseLink.href.includes('.raw')) {
-      assets.browse.type = 'images/raw';
+      assets.browse.type = 'image/raw';
     } else {
-      assets.browse.type = 'images/jpeg';
+      assets.browse.type = 'image/jpeg';
     }
   }
   if (opendapLink) {

--- a/search/lib/convert/granules.js
+++ b/search/lib/convert/granules.js
@@ -92,19 +92,23 @@ function cmrGranToFeatureGeoJSON (event, cmrGran) {
   if (browseLink) {
     assets.browse = linkToAsset(browseLink);
 
-    if (browseLink.href.includes('.png')) {
-      assets.browse.type = 'image/png';
-    }
-    if (browseLink.href.includes('.tiff')) {
-      assets.browse.type = 'image/tiff';
-    }
-    if (browseLink.href.includes('.tif')) {
-      assets.browse.type = 'image/tiff';
-    }
-    if (browseLink.href.includes('.raw')) {
-      assets.browse.type = 'image/raw';
-    } else {
-      assets.browse.type = 'image/jpeg';
+    const splitBrowseLink = browseLink.href.split('.');
+    const browseExtension = splitBrowseLink[splitBrowseLink.length - 1];
+
+    switch (browseExtension) {
+      case 'png':
+        assets.browse.type = 'image/png';
+        break;
+      case 'tiff':
+      case 'tif':
+        assets.browse.type = 'image/tiff';
+        break;
+      case 'raw':
+        assets.browse.type = 'image/raw';
+        break;
+      default:
+        assets.browse.type = 'image/jpeg';
+        break;
     }
   }
   if (opendapLink) {

--- a/search/tests/convert/granules.spec.js
+++ b/search/tests/convert/granules.spec.js
@@ -196,7 +196,7 @@ describe('granuleToItem', () => {
         assets: {
           browse: {
             href: 'http://example.com/images/abc.jpg',
-            type: 'images/jpeg'
+            type: 'image/jpeg'
           },
           metadata: {
             href: 'https://cmr.earthdata.nasa.gov/search/concepts/1.xml',


### PR DESCRIPTION
## Overview
This branch has a quick fix for the image types set for browse images. Previously it was 'images' when MIME standards say it should be 'image'. 
I also did a small refactor of a longer series of if statements to improve readability and performance. 