### PR TITLE
[SCV-75] Fix New Collection and Item IDs (5/20 UAT Build)

### DIFF
--- a/search/lib/convert/collections.js
+++ b/search/lib/convert/collections.js
@@ -57,19 +57,19 @@ function createExtent (cmrCollection) {
 
 function createLinks (event, cmrCollection) {
   return [
-    wfs.createLink('self', generateAppUrl(event, `/collections/${cmrCollection.short_name}`),
+    wfs.createLink('self', generateAppUrl(event, `/collections/${cmrCollection.id}`),
       'Info about this collection'),
-    wfs.createLink('stac', stacSearchWithCurrentParams(event, cmrCollection.short_name),
+    wfs.createLink('stac', stacSearchWithCurrentParams(event, cmrCollection.id),
       'STAC Search this collection'),
-    wfs.createLink('cmr', cmrGranuleSearchWithCurrentParams(event, cmrCollection.short_name),
+    wfs.createLink('cmr', cmrGranuleSearchWithCurrentParams(event, cmrCollection.id),
       'CMR Search this collection'),
-    wfs.createLink('items', generateAppUrl(event, `/collections/${cmrCollection.short_name}/items`),
+    wfs.createLink('items', generateAppUrl(event, `/collections/${cmrCollection.id}/items`),
       'Granules in this collection'),
-    wfs.createLink('overview', cmr.makeCmrSearchUrl(`/concepts/${cmrCollection.short_name}.html`),
+    wfs.createLink('overview', cmr.makeCmrSearchUrl(`/concepts/${cmrCollection.id}.html`),
       'HTML metadata for collection'),
-    wfs.createLink('metadata', cmr.makeCmrSearchUrl(`/concepts/${cmrCollection.short_name}.native`),
+    wfs.createLink('metadata', cmr.makeCmrSearchUrl(`/concepts/${cmrCollection.id}.native`),
       'Native metadata for collection'),
-    wfs.createLink('metadata', cmr.makeCmrSearchUrl(`/concepts/${cmrCollection.short_name}.umm_json`),
+    wfs.createLink('metadata', cmr.makeCmrSearchUrl(`/concepts/${cmrCollection.id}.umm_json`),
       'JSON metadata for collection')
   ];
 }

--- a/search/lib/convert/granules.js
+++ b/search/lib/convert/granules.js
@@ -123,7 +123,7 @@ function cmrGranToFeatureGeoJSON (event, cmrGran) {
       {
         rel: 'self',
         href: generateAppUrl(event,
-          `/collections/${cmrGran.collection_concept_id}/items/${cmrGran.producer_granule_id}`)
+          `/collections/${cmrGran.collection_concept_id}/items/${cmrGran.id}`)
       },
       {
         rel: 'parent',

--- a/search/tests/convert/collections.spec.js
+++ b/search/tests/convert/collections.spec.js
@@ -139,37 +139,37 @@ describe('collections', () => {
         },
         links: [
           {
-            href: 'http://example.com/cmr-stac/collections/LAADS',
+            href: 'http://example.com/cmr-stac/collections/id',
             rel: 'self',
             title: 'Info about this collection',
             type: 'application/json'
           }, {
-            href: 'http://example.com/cmr-stac/stac/search?collectionId=LAADS',
+            href: 'http://example.com/cmr-stac/stac/search?collectionId=id',
             rel: 'stac',
             title: 'STAC Search this collection',
             type: 'application/json'
           }, {
-            href: 'https://cmr.earthdata.nasa.gov/search/granules.json?collection_concept_id=LAADS',
+            href: 'https://cmr.earthdata.nasa.gov/search/granules.json?collection_concept_id=id',
             rel: 'cmr',
             title: 'CMR Search this collection',
             type: 'application/json'
           }, {
-            href: 'http://example.com/cmr-stac/collections/LAADS/items',
+            href: 'http://example.com/cmr-stac/collections/id/items',
             rel: 'items',
             title: 'Granules in this collection',
             type: 'application/json'
           }, {
-            href: 'https://cmr.earthdata.nasa.gov/search/concepts/LAADS.html',
+            href: 'https://cmr.earthdata.nasa.gov/search/concepts/id.html',
             rel: 'overview',
             title: 'HTML metadata for collection',
             type: 'text/html'
           }, {
-            href: 'https://cmr.earthdata.nasa.gov/search/concepts/LAADS.xml',
+            href: 'https://cmr.earthdata.nasa.gov/search/concepts/id.xml',
             rel: 'metadata',
             title: 'Native metadata for collection',
             type: 'application/xml'
           }, {
-            href: 'https://cmr.earthdata.nasa.gov/search/concepts/LAADS.umm_json',
+            href: 'https://cmr.earthdata.nasa.gov/search/concepts/id.umm_json',
             rel: 'metadata',
             title: 'JSON metadata for collection',
             type: 'application/json'
@@ -198,37 +198,37 @@ describe('collections', () => {
         },
         links: [
           {
-            href: 'http://example.com/cmr-stac/collections/LAADS',
+            href: 'http://example.com/cmr-stac/collections/id',
             rel: 'self',
             title: 'Info about this collection',
             type: 'application/json'
           }, {
-            href: 'http://example.com/cmr-stac/stac/search?collectionId=LAADS',
+            href: 'http://example.com/cmr-stac/stac/search?collectionId=id',
             rel: 'stac',
             title: 'STAC Search this collection',
             type: 'application/json'
           }, {
-            href: 'https://cmr.earthdata.nasa.gov/search/granules.json?collection_concept_id=LAADS',
+            href: 'https://cmr.earthdata.nasa.gov/search/granules.json?collection_concept_id=id',
             rel: 'cmr',
             title: 'CMR Search this collection',
             type: 'application/json'
           }, {
-            href: 'http://example.com/cmr-stac/collections/LAADS/items',
+            href: 'http://example.com/cmr-stac/collections/id/items',
             rel: 'items',
             title: 'Granules in this collection',
             type: 'application/json'
           }, {
-            href: 'https://cmr.earthdata.nasa.gov/search/concepts/LAADS.html',
+            href: 'https://cmr.earthdata.nasa.gov/search/concepts/id.html',
             rel: 'overview',
             title: 'HTML metadata for collection',
             type: 'text/html'
           }, {
-            href: 'https://cmr.earthdata.nasa.gov/search/concepts/LAADS.xml',
+            href: 'https://cmr.earthdata.nasa.gov/search/concepts/id.xml',
             rel: 'metadata',
             title: 'Native metadata for collection',
             type: 'application/xml'
           }, {
-            href: 'https://cmr.earthdata.nasa.gov/search/concepts/LAADS.umm_json',
+            href: 'https://cmr.earthdata.nasa.gov/search/concepts/id.umm_json',
             rel: 'metadata',
             title: 'JSON metadata for collection',
             type: 'application/json'

--- a/search/tests/convert/granules.spec.js
+++ b/search/tests/convert/granules.spec.js
@@ -206,7 +206,7 @@ describe('granuleToItem', () => {
         links: [
           {
             rel: 'self',
-            href: 'http://example.com/cmr-stac/collections/10/items/AST_L1A#00310102016013836_10112016120846.hdf'
+            href: 'http://example.com/cmr-stac/collections/10/items/1'
           },
           {
             rel: 'parent',
@@ -274,7 +274,7 @@ describe('granuleToItem', () => {
           links: [
             {
               rel: 'self',
-              href: 'http://example.com/cmr-stac/collections/10/items/AST_L1A#00310102016013836_10112016120846.hdf'
+              href: 'http://example.com/cmr-stac/collections/10/items/1'
             },
             {
               rel: 'parent',


### PR DESCRIPTION
## Overview
This branch is the fix/update for the UAT 5/20 UAT build in which links in collections and items were broken. 

## The Problem
The issue was that in the branch for the original tickets (SCV-27 and SCV-28), we were trying to surface `short_name` instead of `id`. The motivation to do so was that STAC users typically use the `short_name`, and would be less familiar with the CMR `id`. 
However, when replacing `id` with `short_name` in the links broke them since a `collections/{short_name}` query to CMR results in an error. 

## The Solution
In order to keep the updated IDs and still have functioning links, I reverted the link-builder to use the CMR collection and item IDs while still surfacing `short_name` in the description. 

## Future Work
I would hazard a guess that we're going to have some additional work that relates to this ticket when it comes to Search. If STAC users are accustomed to using `short_name`, then they're probably going to use it when searching for collections. Perhaps this might take the form of adding `short_name` as a possible query param for Search, or doing a small conversion so that the CMR query uses the STAC query's `id` as `short_name`. Either way, it'll need to be discussed.