### PR TITLE
HOTFIX Remove "proprietary" from license in collections

### DIFF
--- a/search/lib/convert/collections.js
+++ b/search/lib/convert/collections.js
@@ -80,7 +80,7 @@ function cmrCollToWFSColl (event, cmrCollection) {
   return {
     id: cmrCollection.id,
     stac_version: settings.stac.version,
-    license: cmrCollection.license || 'proprietary',
+    license: cmrCollection.license || '',
     title: cmrCollection.dataset_id,
     description: cmrCollection.summary,
     links: createLinks(event, cmrCollection),

--- a/search/lib/convert/collections.js
+++ b/search/lib/convert/collections.js
@@ -80,7 +80,7 @@ function cmrCollToWFSColl (event, cmrCollection) {
   return {
     id: cmrCollection.id,
     stac_version: settings.stac.version,
-    license: cmrCollection.license || '',
+    license: cmrCollection.license || null,
     title: cmrCollection.dataset_id,
     description: cmrCollection.summary,
     links: createLinks(event, cmrCollection),

--- a/search/tests/convert/collections.spec.js
+++ b/search/tests/convert/collections.spec.js
@@ -113,6 +113,7 @@ describe('collections', () => {
     const cmrCollTemporal = {
       id: 'id',
       dataset_id: 'datasetId',
+      license: 'apache 2.0',
       summary: 'summary',
       time_start: '2009-01-01T00:00:00Z'
     };
@@ -177,7 +178,7 @@ describe('collections', () => {
         id: 'id',
         title: 'datasetId',
         stac_version: settings.stac.version,
-        license: 'proprietary'
+        license: ''
       });
     });
 
@@ -239,7 +240,7 @@ describe('collections', () => {
         id: 'id',
         title: 'datasetId',
         stac_version: settings.stac.version,
-        license: 'proprietary'
+        license: 'apache 2.0'
       });
     });
   });

--- a/search/tests/convert/collections.spec.js
+++ b/search/tests/convert/collections.spec.js
@@ -178,7 +178,7 @@ describe('collections', () => {
         id: 'id',
         title: 'datasetId',
         stac_version: settings.stac.version,
-        license: ''
+        license: null
       });
     });
 


### PR DESCRIPTION
## Overview
This branch removes the 'proprietary' keyword from the license field. Now, the conversion will look for a `license` field in the CMR collection, and either use this or leave this field as null. This will mean it won't always be STAC compliant, but this was OKed by the client.