### PR TITLE
[SCV-84] Missing License Value

### DIFF
--- a/search/lib/convert/collections.js
+++ b/search/lib/convert/collections.js
@@ -80,7 +80,7 @@ function cmrCollToWFSColl (event, cmrCollection) {
   return {
     id: cmrCollection.id,
     stac_version: settings.stac.version,
-    license: cmrCollection.license || 'proprietary',
+    license: cmrCollection.license || 'Not Provided',
     title: cmrCollection.dataset_id,
     description: cmrCollection.summary,
     links: createLinks(event, cmrCollection),

--- a/search/tests/convert/collections.spec.js
+++ b/search/tests/convert/collections.spec.js
@@ -104,6 +104,7 @@ describe('collections', () => {
   describe('cmrCollToWFSCol', () => {
     const cmrColl = {
       id: 'id',
+      license: 'Apache-2.0',
       dataset_id: 'datasetId',
       summary: 'summary',
       time_start: '0',
@@ -177,7 +178,7 @@ describe('collections', () => {
         id: 'id',
         title: 'datasetId',
         stac_version: settings.stac.version,
-        license: 'proprietary'
+        license: 'Apache-2.0'
       });
     });
 
@@ -239,7 +240,7 @@ describe('collections', () => {
         id: 'id',
         title: 'datasetId',
         stac_version: settings.stac.version,
-        license: 'proprietary'
+        license: 'Not Provided'
       });
     });
   });


### PR DESCRIPTION
## Overview
This branch contains a quick adjustment to the license return value for collections. If there is no license information in the metadata, it is given the value of `license: "Not Provided"`.