### PR TITLE
[SCV-112] Add `context` extension to search responses

### DIFF
--- a/search/lib/api/stac.js
+++ b/search/lib/api/stac.js
@@ -7,13 +7,13 @@ const stacExtension = require('../stac/extension');
 const { assertValid, schemas } = require('../validator');
 const { logger, makeAsyncHandler } = require('../util');
 
-async function search (event, params) {
+async function search(event, params) {
   const cmrParams = cmr.convertParams(cmr.STAC_SEARCH_PARAMS_CONVERSION_MAP, params);
-  const granules = await cmr.findGranules(cmrParams);
-  return cmrConverter.cmrGranulesToFeatureCollection(event, granules);
+  const granulesResult = await cmr.findGranules(cmrParams);
+  return cmrConverter.cmrGranulesToFeatureCollection(event, granulesResult);
 }
 
-async function getSearch (request, response) {
+async function getSearch(request, response) {
   const providerId = request.params.providerId;
   logger.info(`GET /${providerId}/search`);
   const event = request.apiGateway.event;
@@ -26,7 +26,7 @@ async function getSearch (request, response) {
   response.status(200).json(formatedResult);
 }
 
-async function postSearch (request, response) {
+async function postSearch(request, response) {
   const providerId = request.params.providerId;
   logger.info(`POST /${providerId}/search`);
   const event = request.apiGateway.event;

--- a/search/lib/api/wfs.js
+++ b/search/lib/api/wfs.js
@@ -95,10 +95,10 @@ async function getGranules (request, response) {
         provider: providerId },
       cmr.convertParams(cmr.WFS_PARAMS_CONVERSION_MAP, request.query)
     );
-    const granules = await cmr.findGranules(params);
+    const granulesResult = await cmr.findGranules(params);
     const granulesUmm = await cmr.findGranulesUmm(params);
-    if (!granules.length) throw new Error('Items not found');
-    const granulesResponse = convert.cmrGranulesToFeatureCollection(event, granules, granulesUmm);
+    if (!granulesResult.granules.length) throw new Error('Items not found');
+    const granulesResponse = convert.cmrGranulesToFeatureCollection(event, granulesResult, granulesUmm);
     await assertValid(schemas.items, granulesResponse);
     response.status(200).json(granulesResponse);
   } catch (e) {
@@ -117,7 +117,7 @@ async function getGranule (request, response) {
     provider: request.params.providerId,
     concept_id: conceptId
   };
-  const granules = await cmr.findGranules(granParams);
+  const granules = (await cmr.findGranules(granParams)).granules;
   const granulesUmm = await cmr.findGranulesUmm(granParams);
   const granuleResponse = convert.cmrGranToFeatureGeoJSON(event, granules[0], granulesUmm[0]);
   await assertValid(schemas.item, granuleResponse);

--- a/search/lib/cmr.js
+++ b/search/lib/cmr.js
@@ -59,7 +59,9 @@ async function getCollection (conceptId, providerId) {
 
 async function findGranules (params = {}) {
   const response = await cmrSearch(makeCmrSearchUrl('/granules.json'), params);
-  return response.data.feed.entry;
+  const granules = response.data.feed.entry
+  const totalHits = _.get(response, 'headers.cmr-hits', granules.length)
+  return { granules: granules, totalHits: totalHits };
 }
 
 async function findGranulesUmm (params = {}) {

--- a/search/lib/convert/granules.js
+++ b/search/lib/convert/granules.js
@@ -231,7 +231,8 @@ function cmrGranToFeatureGeoJSON (event, cmrGran, cmrGranUmm = {}) {
   };
 }
 
-function cmrGranulesToFeatureCollection (event, cmrGrans, cmrGransUmm = []) {
+function cmrGranulesToFeatureCollection(event, cmrGranulesResult, cmrGransUmm = []) {
+  const cmrGrans = cmrGranulesResult.granules;
   const currPage = parseInt(extractParam(event.queryStringParameters, 'page_num', '1'), 10);
   const nextPage = currPage + 1;
   const prevPage = currPage - 1;
@@ -251,11 +252,15 @@ function cmrGranulesToFeatureCollection (event, cmrGrans, cmrGransUmm = []) {
   } else {
     features = cmrGrans.map(gran => cmrGranToFeatureGeoJSON(event, gran));
   }
-
   const granulesResponse = {
     type: 'FeatureCollection',
     stac_version: settings.stac.version,
     features: features,
+    context: {
+      returned: features.length,
+      limit: (event.queryStringParameters && event.queryStringParameters.limit) || null,
+      matched: cmrGranulesResult.totalHits,
+    },
     links: [
       {
         rel: 'self',

--- a/search/tests/api/stac.spec.js
+++ b/search/tests/api/stac.spec.js
@@ -18,7 +18,7 @@ describe('STAC Search', () => {
       params: { providerId: 'LPDAAC' }
     });
     response = createMockResponse();
-    mockFunction(cmr, 'findGranules', Promise.resolve(exampleData.cmrGrans));
+    mockFunction(cmr, 'findGranules', Promise.resolve({ granules: exampleData.cmrGrans, totalHits: 19 }));
   });
 
   afterEach(() => {
@@ -29,6 +29,11 @@ describe('STAC Search', () => {
     type: 'FeatureCollection',
     stac_version: settings.stac.version,
     features: exampleData.stacGrans,
+    context: {
+      limit: null,
+      matched: 19,
+      returned: 2
+    },
     links: [
       {
         rel: 'self',

--- a/search/tests/api/wfs.spec.js
+++ b/search/tests/api/wfs.spec.js
@@ -23,7 +23,7 @@ describe('wfs routes', () => {
     response = createMockResponse();
     mockFunction(cmr, 'findCollections', Promise.resolve(exampleData.cmrColls));
     mockFunction(cmr, 'getCollection', Promise.resolve(exampleData.cmrColls[0]));
-    mockFunction(cmr, 'findGranules', Promise.resolve(exampleData.cmrGrans));
+    mockFunction(cmr, 'findGranules', Promise.resolve({ granules: exampleData.cmrGrans, totalHits: exampleData.cmrGrans.length }));
     mockFunction(cmr, 'findGranulesUmm', Promise.resolve(exampleData.cmrGransUmm));
   });
 
@@ -92,6 +92,11 @@ describe('wfs routes', () => {
       response.expect({
         type: 'FeatureCollection',
         stac_version: settings.stac.version,
+        context: {
+          limit: null,
+          matched: 2,
+          returned: 2,
+        },
         links: [
           {
             rel: 'self',
@@ -112,6 +117,11 @@ describe('wfs routes', () => {
       response.expect({
         type: 'FeatureCollection',
         stac_version: settings.stac.version,
+        context: {
+          limit: null,
+          matched: 2,
+          returned: 2,
+        },
         links: [
           {
             rel: 'self',

--- a/search/tests/cmr/cmr.spec.js
+++ b/search/tests/cmr/cmr.spec.js
@@ -100,7 +100,7 @@ describe('cmr', () => {
   describe('findGranules', () => {
     beforeEach(() => {
       axios.get = jest.fn();
-      const cmrResponse = { data: { feed: { entry: { test: 'value' } } } };
+      const cmrResponse = { headers: { "cmr-hits": 199 }, data: { feed: { entry: [{ test: 'value' }] } } };
       axios.get.mockResolvedValue(cmrResponse);
     });
 
@@ -108,21 +108,34 @@ describe('cmr', () => {
       jest.restoreAllMocks();
     });
 
-    it('should return a url with /granules.json appended', async () => {
+    it('makes a request to /granules.json', async () => {
+      await findGranules();
+
+      expect(axios.get.mock.calls.length).toBe(1);
+      expect(axios.get.mock.calls[0][0]).toBe('https://cmr.earthdata.nasa.gov/search/granules.json');
+    });
+
+    it('makes a request with the supplied params', async () => {
+      await findGranules(params);
+
+      expect(axios.get.mock.calls.length).toBe(1);
+      expect(axios.get.mock.calls[0][1]).toEqual({ params: { param: 'test' }, headers: { 'Client-Id': 'cmr-stac-api-proxy' } });
+    });
+
+    it('returns an object with the returned granules', async () => {
       const result = await findGranules();
 
       expect(axios.get.mock.calls.length).toBe(1);
       expect(axios.get.mock.calls[0][0]).toBe('https://cmr.earthdata.nasa.gov/search/granules.json');
-      expect(result).toEqual({ test: 'value' });
+      expect(result).toEqual(expect.objectContaining({ granules: [{ test: 'value' }] }));
     });
 
-    it('should return a url with /granules.json appended and params', async () => {
+    it('returns totalHits from the CMR response header "cmr-hits"', async () => {
       const result = await findGranules(params);
 
       expect(axios.get.mock.calls.length).toBe(1);
       expect(axios.get.mock.calls[0][0]).toBe('https://cmr.earthdata.nasa.gov/search/granules.json');
-      expect(axios.get.mock.calls[0][1]).toEqual({ params: { param: 'test' }, headers: { 'Client-Id': 'cmr-stac-api-proxy' } });
-      expect(result).toEqual({ test: 'value' });
+      expect(result).toEqual(expect.objectContaining({ totalHits: 199 }));
     });
   });
 

--- a/search/tests/convert/granules.spec.js
+++ b/search/tests/convert/granules.spec.js
@@ -286,10 +286,16 @@ describe('granuleToItem', () => {
 
     const event = { headers: { Host: 'example.com' }, path: '/cmr-stac', queryStringParameters: [] };
 
-    it('should return a cmrGranule to a FeatureCollection', () => {
-      expect(cmrGranulesToFeatureCollection(event, cmrGran)).toEqual({
+    it('should return a CMR Granules search result to a FeatureCollection', () => {
+      const granulesSearchResult = { granules: cmrGran, totalHits: 12345 }
+      expect(cmrGranulesToFeatureCollection(event, granulesSearchResult)).toEqual({
         type: 'FeatureCollection',
         stac_version: settings.stac.version,
+        context: {
+          limit: null,
+          matched: 12345,
+          returned: 1
+        },
         features: [{
           id: 1,
           stac_version: settings.stac.version,


### PR DESCRIPTION
# Problem

We want to try implementing the [`context` extension](https://github.com/radiantearth/stac-api-spec/tree/master/extensions). Which provides some information about search results.

# Solution

Using the CMR `num-hits` header and other information, construct a context object containing `returned`,`limit`, and `matched` attributes about the search.