### PR TITLE
[SCV-113] Implement sort extension

### DIFF
--- a/docs/postman-collection.stac-cmr-proxy.json
+++ b/docs/postman-collection.stac-cmr-proxy.json
@@ -395,7 +395,36 @@
         "followAuthorizationHeader": false
       },
       "response": []
-    }
+    },
+    {
+			"name": "GET Provider Search with Sort",
+			"request": {
+				"method": "GET",
+				"header": [],
+				"url": {
+					"raw": "{{protocol}}://{{host}}/ASF/search?collections=C1213921626-ASF&sortby=-properties.datetime",
+					"protocol": "{{protocol}}",
+					"host": [
+						"{{host}}"
+					],
+					"path": [
+						"ASF",
+						"search"
+					],
+					"query": [
+						{
+							"key": "collections",
+							"value": "C1213921626-ASF"
+						},
+						{
+							"key": "sortby",
+							"value": "-properties.datetime"
+						}
+					]
+				}
+			},
+			"response": []
+		}
   ]
 }
 

--- a/search/lib/api/stac.js
+++ b/search/lib/api/stac.js
@@ -15,28 +15,44 @@ async function search (event, params) {
 }
 
 async function getSearch (request, response) {
-  const providerId = request.params.providerId;
-  logger.info(`GET /${providerId}/search`);
-  const event = request.apiGateway.event;
-  const query = stacExtension.stripStacExtensionsFromRequestObject(request.query); // The cmr function to convert params can not handle stac extensions
-  const params = Object.assign({ provider: providerId }, query);
-  const convertedParams = cmr.convertParams(cmr.STAC_QUERY_PARAMS_CONVERSION_MAP, params);
-  const { searchResult, featureCollection } = await search(event, convertedParams);
-  await assertValid(schemas.items, featureCollection);
-  const formatted = stacExtension.applyStacExtensions(featureCollection, { fields: request.query.fields, context: { searchResult, query } }); // Apply any stac extensions that are present
-  response.status(200).json(formatted);
+  try {
+    const providerId = request.params.providerId;
+    logger.info(`GET /${providerId}/search`);
+    const event = request.apiGateway.event;
+    const query = stacExtension.prepare(request.query);
+    const params = Object.assign({ provider: providerId }, query);
+    const convertedParams = cmr.convertParams(cmr.STAC_QUERY_PARAMS_CONVERSION_MAP, params);
+    const { searchResult, featureCollection } = await search(event, convertedParams);
+    await assertValid(schemas.items, featureCollection);
+    const formatted = stacExtension.format(featureCollection, { fields: request.query.fields, context: { searchResult, query } }); // Apply any stac extensions that are present
+    response.status(200).json(formatted);
+  } catch (error) {
+    if (error instanceof stacExtension.errors.InvalidSortPropertyError) {
+      response.status(422).json(error.message);
+    } else {
+      throw error;
+    }
+  }
 }
 
 async function postSearch (request, response) {
-  const providerId = request.params.providerId;
-  logger.info(`POST /${providerId}/search`);
-  const event = request.apiGateway.event;
-  const body = stacExtension.stripStacExtensionsFromRequestObject(request.body);
-  const params = Object.assign({ provider: providerId }, body);
-  const { searchResult, featureCollection } = await search(event, params);
-  await assertValid(schemas.items, featureCollection);
-  const formatted = stacExtension.applyStacExtensions(featureCollection, { fields: request.body.fields, context: { searchResult, query: params } }); // Apply any stac extensions that are present
-  response.status(200).json(formatted);
+  try {
+    const providerId = request.params.providerId;
+    logger.info(`POST /${providerId}/search`);
+    const event = request.apiGateway.event;
+    const body = stacExtension.prepare(request.body);
+    const params = Object.assign({ provider: providerId }, body);
+    const { searchResult, featureCollection } = await search(event, params);
+    await assertValid(schemas.items, featureCollection);
+    const formatted = stacExtension.format(featureCollection, { fields: request.body.fields, context: { searchResult, query: params } }); // Apply any stac extensions that are present
+    response.status(200).json(formatted);
+  } catch (error) {
+    if (error instanceof stacExtension.InvalidSortPropertyError) {
+      response.status(422).json(error.message);
+    } else {
+      throw error;
+    }
+  }
 }
 
 const routes = express.Router();

--- a/search/lib/api/stac.js
+++ b/search/lib/api/stac.js
@@ -9,8 +9,9 @@ const { logger, makeAsyncHandler } = require('../util');
 
 async function search (event, params) {
   const cmrParams = cmr.convertParams(cmr.STAC_SEARCH_PARAMS_CONVERSION_MAP, params);
-  const granules = await cmr.findGranules(cmrParams);
-  return cmrConverter.cmrGranulesToFeatureCollection(event, granules);
+  const searchResult = await cmr.findGranules(cmrParams);
+
+  return { searchResult, featureCollection: cmrConverter.cmrGranulesToFeatureCollection(event, searchResult.granules) };
 }
 
 async function getSearch (request, response) {
@@ -20,10 +21,10 @@ async function getSearch (request, response) {
   const query = stacExtension.stripStacExtensionsFromRequestObject(request.query); // The cmr function to convert params can not handle stac extensions
   const params = Object.assign({ provider: providerId }, query);
   const convertedParams = cmr.convertParams(cmr.STAC_QUERY_PARAMS_CONVERSION_MAP, params);
-  const result = await search(event, convertedParams);
-  await assertValid(schemas.items, result);
-  const formatedResult = stacExtension.applyStacExtensions(request.query, result); // Apply any stac extensions that are present
-  response.status(200).json(formatedResult);
+  const { searchResult, featureCollection } = await search(event, convertedParams);
+  await assertValid(schemas.items, featureCollection);
+  const formatted = stacExtension.applyStacExtensions(featureCollection, { fields: request.query.fields, context: { searchResult, query } }); // Apply any stac extensions that are present
+  response.status(200).json(formatted);
 }
 
 async function postSearch (request, response) {
@@ -32,10 +33,10 @@ async function postSearch (request, response) {
   const event = request.apiGateway.event;
   const body = stacExtension.stripStacExtensionsFromRequestObject(request.body);
   const params = Object.assign({ provider: providerId }, body);
-  const result = await search(event, params);
-  await assertValid(schemas.items, result);
-  const formatedResult = stacExtension.applyStacExtensions(request.body, result); // Apply any stac extensions that are present
-  response.status(200).json(formatedResult);
+  const { searchResult, featureCollection } = await search(event, params);
+  await assertValid(schemas.items, featureCollection);
+  const formatted = stacExtension.applyStacExtensions(featureCollection, { fields: request.body.fields, context: { searchResult, query: params } }); // Apply any stac extensions that are present
+  response.status(200).json(formatted);
 }
 
 const routes = express.Router();

--- a/search/lib/api/wfs.js
+++ b/search/lib/api/wfs.js
@@ -6,7 +6,7 @@ const convert = require('../convert');
 const { assertValid, schemas } = require('../validator');
 const settings = require('../settings');
 
-class NotFoundError extends Error {}
+class NotFoundError extends Error { }
 
 async function getCollections (request, response) {
   try {
@@ -91,14 +91,16 @@ async function getGranules (request, response) {
     logger.info(`GET /${providerId}/collections/${conceptId}/items`);
     const event = request.apiGateway.event;
     const params = Object.assign(
-      { collection_concept_id: conceptId,
-        provider: providerId },
+      {
+        collection_concept_id: conceptId,
+        provider: providerId
+      },
       cmr.convertParams(cmr.WFS_PARAMS_CONVERSION_MAP, request.query)
     );
-    const granules = await cmr.findGranules(params);
+    const granulesResult = await cmr.findGranules(params);
     const granulesUmm = await cmr.findGranulesUmm(params);
-    if (!granules.length) throw new Error('Items not found');
-    const granulesResponse = convert.cmrGranulesToFeatureCollection(event, granules, granulesUmm);
+    if (!granulesResult.granules.length) throw new Error('Items not found');
+    const granulesResponse = convert.cmrGranulesToFeatureCollection(event, granulesResult.granules, granulesUmm);
     await assertValid(schemas.items, granulesResponse);
     response.status(200).json(granulesResponse);
   } catch (e) {
@@ -117,7 +119,7 @@ async function getGranule (request, response) {
     provider: request.params.providerId,
     concept_id: conceptId
   };
-  const granules = await cmr.findGranules(granParams);
+  const granules = (await cmr.findGranules(granParams)).granules;
   const granulesUmm = await cmr.findGranulesUmm(granParams);
   const granuleResponse = convert.cmrGranToFeatureGeoJSON(event, granules[0], granulesUmm[0]);
   await assertValid(schemas.item, granuleResponse);

--- a/search/lib/cmr.js
+++ b/search/lib/cmr.js
@@ -59,7 +59,9 @@ async function getCollection (conceptId, providerId) {
 
 async function findGranules (params = {}) {
   const response = await cmrSearch(makeCmrSearchUrl('/granules.json'), params);
-  return response.data.feed.entry;
+  const granules = response.data.feed.entry;
+  const totalHits = _.get(response, 'headers.cmr-hits', granules.length);
+  return { granules: granules, totalHits: totalHits };
 }
 
 async function findGranulesUmm (params = {}) {

--- a/search/lib/convert/granules.js
+++ b/search/lib/convert/granules.js
@@ -251,7 +251,6 @@ function cmrGranulesToFeatureCollection (event, cmrGrans, cmrGransUmm = []) {
   } else {
     features = cmrGrans.map(gran => cmrGranToFeatureGeoJSON(event, gran));
   }
-
   const granulesResponse = {
     type: 'FeatureCollection',
     stac_version: settings.stac.version,

--- a/search/lib/stac/extension.js
+++ b/search/lib/stac/extension.js
@@ -1,5 +1,5 @@
 const fieldsExtension = require('./extensions/fields');
-const _ = require('lodash');
+const contextExtension = require('./extensions/context');
 
 const EXTENSION_TYPES = {
   fields: 'fields'
@@ -12,15 +12,12 @@ function stripStacExtensionsFromRequestObject (request) {
   return strippedRequestObject;
 }
 
-function applyStacExtensions (extensions, result) {
+function applyStacExtensions (result, options) {
   let resultToReturn = Object.assign({}, result);
-  if (_.hasIn(extensions, EXTENSION_TYPES.fields)) {
-    let fields = extensions.fields;
-    if (typeof fields === 'string' || fields instanceof String) {
-      fields = fieldsExtension.convertStacFieldsQueryToObject(fields);
-    }
-    resultToReturn = fieldsExtension.applyStacFieldsExtension(fields, resultToReturn);
-  }
+
+  resultToReturn = fieldsExtension.apply(resultToReturn, options.fields);
+  resultToReturn = contextExtension.apply(resultToReturn, options.context);
+
   return resultToReturn;
 }
 

--- a/search/lib/stac/extension.js
+++ b/search/lib/stac/extension.js
@@ -1,28 +1,36 @@
 const fieldsExtension = require('./extensions/fields');
 const contextExtension = require('./extensions/context');
+const sortExtension = require('./extensions/sort');
 
 const EXTENSION_TYPES = {
   fields: 'fields'
 };
 
-function stripStacExtensionsFromRequestObject (request) {
-  const strippedRequestObject = Object.assign({}, request);
-  // TODO: All STAC API Extension query params must be stripped from GET requests
-  delete strippedRequestObject.fields;
-  return strippedRequestObject;
+// extensions with `prepare` functions modify the request parameters
+function prepare (params) {
+  let preparedParams = Object.assign({}, params);
+
+  preparedParams = fieldsExtension.prepare(preparedParams);
+  preparedParams = sortExtension.prepare(preparedParams);
+
+  return preparedParams;
 }
 
-function applyStacExtensions (result, options) {
+// extensions with `format` functions modify the api response
+function format (result, options) {
   let resultToReturn = Object.assign({}, result);
 
-  resultToReturn = fieldsExtension.apply(resultToReturn, options.fields);
-  resultToReturn = contextExtension.apply(resultToReturn, options.context);
+  resultToReturn = fieldsExtension.format(resultToReturn, options.fields);
+  resultToReturn = contextExtension.format(resultToReturn, options.context);
 
   return resultToReturn;
 }
 
 module.exports = {
   EXTENSION_TYPES,
-  stripStacExtensionsFromRequestObject,
-  applyStacExtensions
+  prepare,
+  format,
+  errors: {
+    InvalidSortPropertyError: sortExtension.InvalidSortPropertyError
+  }
 };

--- a/search/lib/stac/extensions/context.js
+++ b/search/lib/stac/extensions/context.js
@@ -1,0 +1,12 @@
+function apply (result, { query, searchResult }) {
+  return {
+    ...result,
+    context: {
+      returned: searchResult.granules.length,
+      limit: query.limit || null,
+      matched: searchResult.totalHits
+    }
+  };
+}
+
+module.exports = { apply };

--- a/search/lib/stac/extensions/context.js
+++ b/search/lib/stac/extensions/context.js
@@ -1,4 +1,4 @@
-function apply (result, { query, searchResult }) {
+function format (result, { query, searchResult }) {
   return {
     ...result,
     context: {
@@ -9,4 +9,4 @@ function apply (result, { query, searchResult }) {
   };
 }
 
-module.exports = { apply };
+module.exports = { format };

--- a/search/lib/stac/extensions/fields.js
+++ b/search/lib/stac/extensions/fields.js
@@ -1,14 +1,9 @@
 
 const _ = require('lodash');
 
-function convertStacFieldsQueryToObject (fieldsQuery) {
-  const fieldsArray = fieldsQuery.split(',');
-  const include = fieldsArray.filter(field => field.startsWith('-') === false).map(field => field.replace(/^\+/, ''));
-  const exclude = fieldsArray.filter(field => field.startsWith('-') === true).map(field => field.replace(/^-/, ''));
-  return { include, exclude };
-}
+function apply (result, fields) {
+  if (_.isUndefined(fields) || _.isNull(fields)) return result;
 
-function applyStacFieldsExtension (fields, result) {
   const { _sourceIncludes, _sourceExcludes } = buildFieldsFilter(fields);
 
   result.features = result.features.map(feature => {
@@ -20,15 +15,19 @@ function applyStacFieldsExtension (fields, result) {
   return result;
 }
 
-module.exports = {
-  convertStacFieldsQueryToObject,
-  applyStacFieldsExtension
-};
+module.exports = { apply };
 
 // Private
+function fieldsStringToObject (fieldsQuery) {
+  const fieldsArray = fieldsQuery.split(',');
+  const include = fieldsArray.filter(field => field.startsWith('-') === false).map(field => field.replace(/^\+/, ''));
+  const exclude = fieldsArray.filter(field => field.startsWith('-') === true).map(field => field.replace(/^-/, ''));
+  return { include, exclude };
+}
 
 function buildFieldsFilter (fields) {
-  const { include, exclude } = fields;
+  const fieldsObject = _.isString(fields) ? fieldsStringToObject(fields) : fields;
+  const { include, exclude } = fieldsObject;
   let _sourceIncludes = [
     'id',
     'type',

--- a/search/lib/stac/extensions/fields.js
+++ b/search/lib/stac/extensions/fields.js
@@ -1,7 +1,11 @@
 
 const _ = require('lodash');
 
-function apply (result, fields) {
+function prepare (request) {
+  return _.omit(request, ['fields']);
+}
+
+function format (result, fields) {
   if (_.isUndefined(fields) || _.isNull(fields)) return result;
 
   const { _sourceIncludes, _sourceExcludes } = buildFieldsFilter(fields);
@@ -15,7 +19,7 @@ function apply (result, fields) {
   return result;
 }
 
-module.exports = { apply };
+module.exports = { format, prepare };
 
 // Private
 function fieldsStringToObject (fieldsQuery) {

--- a/search/lib/stac/extensions/sort.js
+++ b/search/lib/stac/extensions/sort.js
@@ -1,0 +1,47 @@
+const _ = require('lodash');
+
+// Map STAC sort parameters to their equivalent CMR names
+const CMR_PROP_MAP = {
+  'properties.start_datetime': 'start_date',
+  'properties.end_datetime': 'end_date',
+  'properties.datetime': 'start_date',
+  short_name: 'short_name'
+};
+
+class InvalidSortPropertyError extends Error {
+  constructor (propertyName) {
+    super(`Property [${propertyName}] does not support sorting`);
+  }
+}
+
+const toCmrField = (stacProp) => {
+  const cmrProp = CMR_PROP_MAP[stacProp];
+
+  if (_.isUndefined(cmrProp)) throw new InvalidSortPropertyError(stacProp);
+
+  return cmrProp || stacProp;
+};
+
+const translateStringParam = (sort) => {
+  const direction = ((sort[0]) === '-' ? '-' : '+');
+  const field = sort.replace(/^[+-]/, '');
+  return direction + toCmrField(field);
+};
+
+const translateObjectParam = ({ field, direction }) => (direction === 'desc' ? '-' : '+') + toCmrField(field);
+const prepObject = (paramsObj) => paramsObj.map(translateObjectParam);
+const prepString = (paramString) => paramString.split(',').map(translateStringParam);
+
+function prepare (params) {
+  const strippedParams = _.omit(params, 'sortby');
+
+  if (_.isString(params.sortby)) {
+    return { ...strippedParams, sort_key: prepString(params.sortby) };
+  } else if (_.isArray(params.sortby)) {
+    return { ...strippedParams, sort_key: prepObject(params.sortby) };
+  }
+
+  return strippedParams;
+}
+
+module.exports = { prepare, InvalidSortPropertyError };

--- a/search/tests/api/extensions/extension.spec.js
+++ b/search/tests/api/extensions/extension.spec.js
@@ -5,7 +5,7 @@
 const _ = require('lodash');
 
 const { createRequest } = require('../../util');
-const { stripStacExtensionsFromRequestObject, applyStacExtensions, EXTENSION_TYPES } = require('../../../lib/stac/extension');
+const { prepare, format, EXTENSION_TYPES } = require('../../../lib/stac/extension');
 const fieldsExtension = require('../../../lib/stac/extensions/fields');
 const contextExtension = require('../../../lib/stac/extensions/context');
 
@@ -807,6 +807,7 @@ describe('STAC API Extensions', () => {
       body: '{}',
       params: {
         providerId: 'LPDAAC',
+        sortby: '+id',
         fields: {
           include: [
             'id',
@@ -824,25 +825,20 @@ describe('STAC API Extensions', () => {
     });
   });
 
-  describe('stripStacExtensionsFromRequestObject', () => {
+  describe('prepare', () => {
     it('should remove all STAC API extensions from the HTTP request', async () => {
-      const strippedRequestObject = stripStacExtensionsFromRequestObject(request);
+      const strippedRequestObject = prepare(request);
 
-      // TODO: We need to add support for all STAC API Extensions (e.g. sort, query, etc)
-      let containsSTACExtensions = false;
-      if (_.hasIn(strippedRequestObject, EXTENSION_TYPES.fields)) {
-        containsSTACExtensions = true;
-      }
-
-      expect(containsSTACExtensions).toBe(false);
+      expect(_.hasIn(strippedRequestObject, EXTENSION_TYPES.fields)).toBe(false);
+      expect(_.hasIn(strippedRequestObject, 'sortby')).toBe(false);
     });
   });
 
-  describe('applyStacExtensions', () => {
+  describe('format', () => {
     it('should execute the suite of STAC API Extensions', async () => {
-      const applyFieldsExtensionSpy = jest.spyOn(fieldsExtension, 'apply');
-      const applyContextExtensionSpy = jest.spyOn(contextExtension, 'apply');
-      applyStacExtensions(result, { fields: request.params.fields, context: { searchResult: { granules: [] }, query: {} } });
+      const applyFieldsExtensionSpy = jest.spyOn(fieldsExtension, 'format');
+      const applyContextExtensionSpy = jest.spyOn(contextExtension, 'format');
+      format(result, { fields: request.params.fields, context: { searchResult: { granules: [] }, query: {} } });
       expect(applyFieldsExtensionSpy).toHaveBeenCalled();
       expect(applyContextExtensionSpy).toHaveBeenCalled();
     });

--- a/search/tests/api/extensions/extension.spec.js
+++ b/search/tests/api/extensions/extension.spec.js
@@ -7,6 +7,7 @@ const _ = require('lodash');
 const { createRequest } = require('../../util');
 const { stripStacExtensionsFromRequestObject, applyStacExtensions, EXTENSION_TYPES } = require('../../../lib/stac/extension');
 const fieldsExtension = require('../../../lib/stac/extensions/fields');
+const contextExtension = require('../../../lib/stac/extensions/context');
 
 describe('STAC API Extensions', () => {
   let request;
@@ -804,7 +805,8 @@ describe('STAC API Extensions', () => {
   beforeEach(() => {
     request = createRequest({
       body: '{}',
-      params: { providerId: 'LPDAAC',
+      params: {
+        providerId: 'LPDAAC',
         fields: {
           include: [
             'id',
@@ -838,10 +840,11 @@ describe('STAC API Extensions', () => {
 
   describe('applyStacExtensions', () => {
     it('should execute the suite of STAC API Extensions', async () => {
-      const applyFieldsExtensionSpy = jest.spyOn(fieldsExtension, 'applyStacFieldsExtension');
-      const extensions = request.params;
-      applyStacExtensions(extensions, result);
+      const applyFieldsExtensionSpy = jest.spyOn(fieldsExtension, 'apply');
+      const applyContextExtensionSpy = jest.spyOn(contextExtension, 'apply');
+      applyStacExtensions(result, { fields: request.params.fields, context: { searchResult: { granules: [] }, query: {} } });
       expect(applyFieldsExtensionSpy).toHaveBeenCalled();
+      expect(applyContextExtensionSpy).toHaveBeenCalled();
     });
   });
 });

--- a/search/tests/api/extensions/sort.spec.js
+++ b/search/tests/api/extensions/sort.spec.js
@@ -1,0 +1,78 @@
+const { prepare, InvalidSortPropertyError } = require('../../../lib/stac/extensions/sort');
+
+/**
+ * @jest-environment node
+ */
+describe('STAC API sort extension', () => {
+  describe('prepare()', () => {
+    it('strips the sortby param', () => {
+      expect(
+        prepare({ sortby: 'short_name' }).sortby
+      ).toBeUndefined();
+      expect(
+        prepare({ sortby: {} }).sortby
+      ).toBeUndefined();
+    });
+    it('is a noop if no argument is given', () => {
+      expect(
+        prepare({ anotherParam: '123' })
+      ).toEqual({ anotherParam: '123' });
+    });
+
+    describe('given a string', () => {
+      it('returns a sort argument for CMR', async () => {
+        expect(
+          prepare({ sortby: 'short_name' })
+        ).toEqual(
+          { sort_key: ['+short_name'] }
+        );
+      });
+
+      it('manages sorting by multiple properties', async () => {
+        expect(
+          prepare({ sortby: 'short_name,-properties.start_datetime,+properties.end_datetime' })
+        ).toEqual(
+          { sort_key: ['+short_name', '-start_date', '+end_date'] }
+        );
+      });
+
+      it('raises an error given a bad property', async () => {
+        expect(
+          () => prepare({ sortby: 'wack-property,-properties.start_datetime' })
+        ).toThrow(InvalidSortPropertyError);
+      });
+    });
+
+    describe('given an object', () => {
+      it('returns a sort argument for CMR', async () => {
+        expect(
+          prepare({ sortby: [{ field: 'short_name', direction: 'asc' }] })
+        ).toEqual(
+          { sort_key: ['+short_name'] }
+        );
+      });
+
+      it('raises an error given a bad property', async () => {
+        expect(
+          () => prepare({ sortby: [{ field: 'short_name', direction: 'desc' }, {
+            field: 'not-a-real-field',
+            direction: 'asc'
+          }] })
+        ).toThrow(InvalidSortPropertyError);
+      });
+
+      it('manages sorting by multiple properties', async () => {
+        expect(
+          prepare({
+            sortby: [{ field: 'short_name', direction: 'desc' }, {
+              field: 'properties.start_datetime',
+              direction: 'asc'
+            }]
+          })
+        ).toEqual(
+          { sort_key: ['-short_name', '+start_date'] }
+        );
+      });
+    });
+  });
+});

--- a/search/tests/api/stac.spec.js
+++ b/search/tests/api/stac.spec.js
@@ -18,7 +18,7 @@ describe('STAC Search', () => {
       params: { providerId: 'LPDAAC' }
     });
     response = createMockResponse();
-    mockFunction(cmr, 'findGranules', Promise.resolve(exampleData.cmrGrans));
+    mockFunction(cmr, 'findGranules', Promise.resolve({ granules: exampleData.cmrGrans, totalHits: 19 }));
   });
 
   afterEach(() => {
@@ -29,6 +29,11 @@ describe('STAC Search', () => {
     type: 'FeatureCollection',
     stac_version: settings.stac.version,
     features: exampleData.stacGrans,
+    context: {
+      limit: null,
+      matched: 19,
+      returned: 2
+    },
     links: [
       {
         rel: 'self',

--- a/search/tests/api/wfs.spec.js
+++ b/search/tests/api/wfs.spec.js
@@ -23,7 +23,7 @@ describe('wfs routes', () => {
     response = createMockResponse();
     mockFunction(cmr, 'findCollections', Promise.resolve(exampleData.cmrColls));
     mockFunction(cmr, 'getCollection', Promise.resolve(exampleData.cmrColls[0]));
-    mockFunction(cmr, 'findGranules', Promise.resolve(exampleData.cmrGrans));
+    mockFunction(cmr, 'findGranules', Promise.resolve({ granules: exampleData.cmrGrans, totalHits: exampleData.cmrGrans.length }));
     mockFunction(cmr, 'findGranulesUmm', Promise.resolve(exampleData.cmrGransUmm));
   });
 

--- a/search/tests/convert/granules.spec.js
+++ b/search/tests/convert/granules.spec.js
@@ -286,7 +286,7 @@ describe('granuleToItem', () => {
 
     const event = { headers: { Host: 'example.com' }, path: '/cmr-stac', queryStringParameters: [] };
 
-    it('should return a cmrGranule to a FeatureCollection', () => {
+    it('should return a CMR Granules search result to a FeatureCollection', () => {
       expect(cmrGranulesToFeatureCollection(event, cmrGran)).toEqual({
         type: 'FeatureCollection',
         stac_version: settings.stac.version,

--- a/search/tests/util.js
+++ b/search/tests/util.js
@@ -64,7 +64,8 @@ function createRequest (additionalData = null) {
     },
     body: '{}',
     app: { logger: logger },
-    params: { }
+    query: {},
+    params: {}
   }, additionalData);
 }
 


### PR DESCRIPTION
# Problem

We want to be able to sort results using the sort extension: 

https://github.com/radiantearth/stac-api-spec/tree/master/extensions

# Solution

Implement a limited scope sort extension. Which allows users to sort by short_name, and the properties start_datetime, end_datetime, and datetime. Which seemed to be the only fields which overlapped with CMR's sorting abilities.

# Implementation

Extend the request preparation pattern for extensions, from just deleting properties, to allow for adding new properties as well. Use the CMR [sort_keys[] functionality](https://cmr.earthdata.nasa.gov/search/site/docs/search/api.html#sorting-granule-results) and map the incoming `sortby` STAC params to the corresponding CMR sort_keys. Raise an error (422) if a property is not specifically supported.