### PR TITLE
small link fixes (resolves CMR-6859, CMR-6860, CMR-6861)

### DIFF
--- a/search/lib/application.js
+++ b/search/lib/application.js
@@ -35,8 +35,8 @@ const rewritePathRoot = (path, alt, allowedAliases) => {
  */
 const urlRewriteMiddleware = (req, res, next) => {
   const routeAliases = settings.cmrStacRouteAliases
-                               .split(',')
-                               .map(s => s.trim());
+    .split(',')
+    .map(s => s.trim());
   req.url = rewritePathRoot(req.url, settings.cmrStacRelativeRootUrl, routeAliases);
   next();
 };

--- a/search/lib/convert/collections.js
+++ b/search/lib/convert/collections.js
@@ -70,7 +70,7 @@ function createLinks (event, cmrCollection) {
   return [
     wfs.createLink('self', generateAppUrl(event, `/${provider}/collections/${id}`),
       'Info about this collection'),
-    wfs.createLink('root', generateAppUrl(event, ""),
+    wfs.createLink('root', generateAppUrl(event, ''),
       'Root catalog'),
     wfs.createLink('parent', generateAppUrl(event, `/${provider}`),
       'Parent catalog'),

--- a/search/lib/convert/collections.js
+++ b/search/lib/convert/collections.js
@@ -70,8 +70,10 @@ function createLinks (event, cmrCollection) {
   return [
     wfs.createLink('self', generateAppUrl(event, `/${provider}/collections/${id}`),
       'Info about this collection'),
-    wfs.createLink('provider', generateAppUrl(event, `/${provider}`),
-      'Root for this provider'),
+    wfs.createLink('root', generateAppUrl(event, ""),
+      'Root catalog'),
+    wfs.createLink('parent', generateAppUrl(event, `/${provider}`),
+      'Parent catalog'),
     wfs.createLink('stac', stacSearchWithCurrentParams(event, id, provider),
       'STAC Search this collection'),
     wfs.createLink('cmr', cmrGranuleSearchWithCurrentParams(event, id),

--- a/search/lib/convert/granules.js
+++ b/search/lib/convert/granules.js
@@ -211,7 +211,7 @@ function cmrGranToFeatureGeoJSON (event, cmrGran, cmrGranUmm = {}) {
       },
       {
         rel: 'parent',
-        href: generateAppUrl(event, `/${cmrGran.data_center}/collections/${cmrGran.collection_concept_id}/items`)
+        href: generateAppUrl(event, `/${cmrGran.data_center}/collections/${cmrGran.collection_concept_id}`)
       },
       {
         rel: 'collection',

--- a/search/tests/convert/collections.spec.js
+++ b/search/tests/convert/collections.spec.js
@@ -164,9 +164,14 @@ describe('collections', () => {
             title: 'Info about this collection',
             type: 'application/json'
           }, {
-            rel: 'provider',
+            rel: 'root',
+            href: 'http://example.com/stac',
+            title: 'Root catalog',
+            type: 'application/json'
+          }, {
+            rel: 'parent',
             href: 'http://example.com/stac/LPDAAC',
-            title: 'Root for this provider',
+            title: 'Parent catalog',
             type: 'application/json'
           }, {
             href: 'http://example.com/stac/LPDAAC/search?collections=id',
@@ -239,9 +244,14 @@ describe('collections', () => {
             title: 'Info about this collection',
             type: 'application/json'
           }, {
-            rel: 'provider',
+            rel: 'root',
+            href: 'http://example.com/stac',
+            title: 'Root catalog',
+            type: 'application/json'
+          }, {
+            rel: 'parent',
             href: 'http://example.com/stac/LPDAAC',
-            title: 'Root for this provider',
+            title: 'Parent catalog',
             type: 'application/json'
           }, {
             href: 'http://example.com/stac/LPDAAC/search?collections=id',

--- a/search/tests/convert/granules.spec.js
+++ b/search/tests/convert/granules.spec.js
@@ -317,7 +317,7 @@ describe('granuleToItem', () => {
             },
             {
               rel: 'parent',
-              href: 'http://example.com/stac/USA/collections/10/items'
+              href: 'http://example.com/stac/USA/collections/10'
             },
             {
               rel: 'collection',

--- a/search/tests/example-data/lancemodis_stac_gran.json
+++ b/search/tests/example-data/lancemodis_stac_gran.json
@@ -44,7 +44,7 @@
     },
     {
       "rel": "parent",
-      "href": "http://example.com/stac/LANCEMODIS/collections/C1426617060-LANCEMODIS/items"
+      "href": "http://example.com/stac/LANCEMODIS/collections/C1426617060-LANCEMODIS"
     },
     {
       "rel": "collection",

--- a/search/tests/example-data/larc_stac_coll.json
+++ b/search/tests/example-data/larc_stac_coll.json
@@ -13,9 +13,15 @@
       "type": "application/json"
     },
     {
-      "rel": "provider",
+      "rel": "root",
+      "href": "http://example.com/stac",
+      "title": "Root catalog",
+      "type": "application/json"
+    },
+    {
+      "rel": "parent",
       "href": "http://example.com/stac/LARC",
-      "title": "Root for this provider",
+      "title": "Parent catalog",
       "type": "application/json"
     },
     {

--- a/search/tests/example-data/lpdaac_stac_coll.json
+++ b/search/tests/example-data/lpdaac_stac_coll.json
@@ -13,9 +13,15 @@
       "type": "application/json"
     },
     {
-      "rel": "provider",
+      "rel": "root",
+      "href": "http://example.com/stac",
+      "title": "Root catalog",
+      "type": "application/json"
+    },
+    {
+      "rel": "parent",
       "href": "http://example.com/stac/LPDAAC_ECS",
-      "title": "Root for this provider",
+      "title": "Parent catalog",
       "type": "application/json"
     },
     {

--- a/search/tests/example-data/lpdaac_stac_gran.json
+++ b/search/tests/example-data/lpdaac_stac_gran.json
@@ -44,7 +44,7 @@
     },
     {
       "rel": "parent",
-      "href": "http://example.com/stac/LPDAAC_ECS/collections/C1328403374-LPDAAC_ECS/items"
+      "href": "http://example.com/stac/LPDAAC_ECS/collections/C1328403374-LPDAAC_ECS"
     },
     {
       "rel": "collection",


### PR DESCRIPTION
Small fixes to links:
CMR-6859: change 'provider' in collection links to 'parent'
CMR-6860: add link to root catalog in collections
CMR-6861: fix parent link in individual items to point to the collection (/collection/<collectionId>), not the set of items within the collection (/collection/<collectionId>/items)

Updates to corresponding tests and fixture data