### PR TITLE
[CMR-6780] pagination

### DIFF
--- a/search/lib/convert/granules.js
+++ b/search/lib/convert/granules.js
@@ -8,7 +8,6 @@ const {
   reorderBoxValues
 } = require('./bounding-box');
 const {
-  logger,
   generateAppUrl,
   wfs,
   generateSelfUrl,
@@ -283,17 +282,13 @@ function cmrGranulesToFeatureCollection (event, cmrGrans, cmrGransUmm = [], para
   // total items up to and including this page
   const totalItems = (currPage - 1) * limit + numberReturned;
 
-  logger.debug(`numberReturned=${numberReturned}, numberMatched=${numberMatched}, totalItems=${totalItems}`);
-
   if (currPage > 1 && totalItems > limit) {
     const navLink = createNavLink(event, params, 'prev');
-    logger.debug(`navLink = ${JSON.stringify(navLink)}`);
     granulesResponse.links.push(navLink);
   }
 
   if (totalItems < numberMatched) {
     const navLink = createNavLink(event, params, 'next');
-    logger.debug(`navLink = ${JSON.stringify(navLink)}`);
     granulesResponse.links.push(navLink);
   }
 

--- a/search/lib/util/index.js
+++ b/search/lib/util/index.js
@@ -117,7 +117,7 @@ function generateNavLinks (event) {
 }
 
 function createNavLink (event, params, rel) {
-  const method = event.requestContext.httpMethod;
+  const method = event.httpMethod;
   const currPage = parseInt(_.get(params, 'page', 1), 10);
 
   const page = (rel === 'prev') ? currPage - 1 : currPage + 1;
@@ -134,12 +134,14 @@ function createNavLink (event, params, rel) {
       body: newParams,
       href: generateAppUrlWithoutRelativeRoot(event, event.path)
     };
-  } else {
+  } else if (method === 'GET') {
     link = {
       rel,
       method,
       href: generateAppUrlWithoutRelativeRoot(event, event.path, newParams)
     };
+  } else {
+    logger.warning('Unable to create navigation links for unknown httpMethod');
   }
 
   return link;

--- a/search/lib/util/index.js
+++ b/search/lib/util/index.js
@@ -141,7 +141,7 @@ function createNavLink (event, params, rel) {
       href: generateAppUrlWithoutRelativeRoot(event, event.path, newParams)
     };
   } else {
-    logger.warning(`Unable to create navigation links for unknown httpMethod: ${method}`);
+    logger.warn(`Unable to create navigation links for unknown httpMethod: ${method}`);
   }
 
   return link;

--- a/search/lib/util/index.js
+++ b/search/lib/util/index.js
@@ -141,7 +141,7 @@ function createNavLink (event, params, rel) {
       href: generateAppUrlWithoutRelativeRoot(event, event.path, newParams)
     };
   } else {
-    logger.warning('Unable to create navigation links for unknown httpMethod');
+    logger.warning(`Unable to create navigation links for unknown httpMethod: ${method}`);
   }
 
   return link;

--- a/search/tests/api/wfs.spec.js
+++ b/search/tests/api/wfs.spec.js
@@ -108,6 +108,7 @@ describe('wfs routes', () => {
 
   describe('getGranules', () => {
     it('should generate a item collection response.', async () => {
+      request.apiGateway.event.httpMethod = 'GET';
       await getGranules(request, response);
       response.expect({
         type: 'FeatureCollection',
@@ -135,6 +136,7 @@ describe('wfs routes', () => {
 
     it('should generate an item collection response with a prev link.', async () => {
       request.apiGateway.event.queryStringParameters = { page: 2 };
+      request.apiGateway.event.httpMethod = 'GET';
       await getGranules(request, response);
       response.expect({
         type: 'FeatureCollection',


### PR DESCRIPTION
This fixes the original CMR-6780 which worked locally but not when deployed. The code was expecting an `httpMethod` field in the event requestContext which was present offline but not when deployed.