### PR TITLE
[CMR-7099] return empty response when no granules returned (none found or limit=0)

### DIFF
--- a/search/lib/api/wfs.js
+++ b/search/lib/api/wfs.js
@@ -150,9 +150,6 @@ async function getGranules (request, response) {
       Object.assign(cmrParams, cmr.stacCollectionToCmrParams(providerId, collectionId));
     }
     const granulesResult = await cmr.findGranules(cmrParams);
-    if (!granulesResult.granules.length) {
-      return response.status(400).json('Items not found');
-    }
 
     const featureCollection = await convert.cmrGranulesToStac(event,
       granulesResult.granules,


### PR DESCRIPTION
When no granules or found, or when limit=0, the response should still be the expected FeatureCollection, but with no features 

numberMatched is still present which is why it's useful to return, because you can make a query, set limit=0, and still see how many hits there were.