### PR TITLE
[CMR-6779] return empty facets if no granules

### DIFF
--- a/search/lib/cmr.js
+++ b/search/lib/cmr.js
@@ -104,41 +104,44 @@ function getFacetParams (year, month, day) {
 async function getGranuleTemporalFacets (params = {}, year, month, day) {
   const cmrParams = Object.assign(params, getFacetParams(year, month, day));
 
-  const facets = {};
+  const facets = {
+    years: [],
+    months: [],
+    days: [],
+    itemids: []
+  };
   const response = await cmrSearch(makeCmrSearchUrl('/granules.json'), cmrParams);
   const cmrFacets = response.data.feed.facets;
-  if (cmrFacets.has_children) {
-    const temporalFacets = cmrFacets.children.find(f => f.title === 'Temporal');
-    // always a year facet
-    const yearFacet = temporalFacets.children.find(f => f.title === 'Year');
-    const years = yearFacet.children.map(y => y.title);
-    facets.years = years;
-    if (year) {
-      // if year provided, get months
-      const monthFacet = yearFacet
-        .children.find(y => y.title === year)
-        .children.find(y => y.title === 'Month');
-      const months = monthFacet.children.map(y => y.title);
-      facets.months = months;
-      if (month) {
-        // if month also provided, get days
-        const days = monthFacet
-          .children.find(y => y.title === month)
-          .children.find(y => y.title === 'Day')
-          .children.map(y => y.title);
-        facets.days = days;
-      }
-      if (day) {
-        const itemids = response.data.feed.entry.map(i => i.id);
-        facets.itemids = itemids;
-      }
-    }
-  } else {
-    facets.years = [];
-    facets.months = [];
-    facets.days = [];
-    facets.itemids = [];
+  if (!cmrFacets.has_children) {
+    return facets;
   }
+
+  const temporalFacets = cmrFacets.children.find(f => f.title === 'Temporal');
+  // always a year facet
+  const yearFacet = temporalFacets.children.find(f => f.title === 'Year');
+  const years = yearFacet.children.map(y => y.title);
+  facets.years = years;
+  if (year) {
+    // if year provided, get months
+    const monthFacet = yearFacet
+      .children.find(y => y.title === year)
+      .children.find(y => y.title === 'Month');
+    const months = monthFacet.children.map(y => y.title);
+    facets.months = months;
+    if (month) {
+      // if month also provided, get days
+      const days = monthFacet
+        .children.find(y => y.title === month)
+        .children.find(y => y.title === 'Day')
+        .children.map(y => y.title);
+      facets.days = days;
+    }
+    if (day) {
+      const itemids = response.data.feed.entry.map(i => i.id);
+      facets.itemids = itemids;
+    }
+  }
+
   return facets;
 }
 

--- a/search/lib/cmr.js
+++ b/search/lib/cmr.js
@@ -134,10 +134,10 @@ async function getGranuleTemporalFacets (params = {}, year, month, day) {
       }
     }
   } else {
-    facets.years = []
-    facets.months = []
-    facets.days = []
-    facets.itemids = []
+    facets.years = [];
+    facets.months = [];
+    facets.days = [];
+    facets.itemids = [];
   }
   return facets;
 }

--- a/search/lib/cmr.js
+++ b/search/lib/cmr.js
@@ -106,30 +106,38 @@ async function getGranuleTemporalFacets (params = {}, year, month, day) {
 
   const facets = {};
   const response = await cmrSearch(makeCmrSearchUrl('/granules.json'), cmrParams);
-  const temporalFacets = response.data.feed.facets.children.find(f => f.title === 'Temporal');
-  // always a year facet
-  const yearFacet = temporalFacets.children.find(f => f.title === 'Year');
-  const years = yearFacet.children.map(y => y.title);
-  facets.years = years;
-  if (year) {
-    // if year provided, get months
-    const monthFacet = yearFacet
-      .children.find(y => y.title === year)
-      .children.find(y => y.title === 'Month');
-    const months = monthFacet.children.map(y => y.title);
-    facets.months = months;
-    if (month) {
-      // if month also provided, get days
-      const days = monthFacet
-        .children.find(y => y.title === month)
-        .children.find(y => y.title === 'Day')
-        .children.map(y => y.title);
-      facets.days = days;
+  const cmrFacets = response.data.feed.facets;
+  if (cmrFacets.has_children) {
+    const temporalFacets = cmrFacets.children.find(f => f.title === 'Temporal');
+    // always a year facet
+    const yearFacet = temporalFacets.children.find(f => f.title === 'Year');
+    const years = yearFacet.children.map(y => y.title);
+    facets.years = years;
+    if (year) {
+      // if year provided, get months
+      const monthFacet = yearFacet
+        .children.find(y => y.title === year)
+        .children.find(y => y.title === 'Month');
+      const months = monthFacet.children.map(y => y.title);
+      facets.months = months;
+      if (month) {
+        // if month also provided, get days
+        const days = monthFacet
+          .children.find(y => y.title === month)
+          .children.find(y => y.title === 'Day')
+          .children.map(y => y.title);
+        facets.days = days;
+      }
+      if (day) {
+        const itemids = response.data.feed.entry.map(i => i.id);
+        facets.itemids = itemids;
+      }
     }
-    if (day) {
-      const itemids = response.data.feed.entry.map(i => i.id);
-      facets.itemids = itemids;
-    }
+  } else {
+    facets.years = []
+    facets.months = []
+    facets.days = []
+    facets.itemids = []
   }
   return facets;
 }

--- a/search/tests/cmr/cmr.spec.js
+++ b/search/tests/cmr/cmr.spec.js
@@ -288,31 +288,32 @@ describe('cmr', () => {
     describe('getGranuleTemporalFacets', () => {
       beforeEach(() => {
         axios.get = jest.fn();
-        const resp = { data: { feed: { facets: { children: [{
-          title: 'Temporal',
+        const resp = { data: { feed: { facets: { has_children: true,
           children: [{
-            title: 'Year',
-            children: [
-              {
-                title: '2001',
-                children: [{
-                  title: 'Month',
-                  children: [
-                    {
-                      title: '05',
-                      children: [{
-                        title: 'Day',
-                        children: [{ title: '20' }, { title: '22' }, { title: '23' }]
-                      }]
-                    },
-                    { title: '06' }
-                  ]
-                }]
-              },
-              { title: '2002' }
-            ]
-          }]
-        }] } } } };
+            title: 'Temporal',
+            children: [{
+              title: 'Year',
+              children: [
+                {
+                  title: '2001',
+                  children: [{
+                    title: 'Month',
+                    children: [
+                      {
+                        title: '05',
+                        children: [{
+                          title: 'Day',
+                          children: [{ title: '20' }, { title: '22' }, { title: '23' }]
+                        }]
+                      },
+                      { title: '06' }
+                    ]
+                  }]
+                },
+                { title: '2002' }
+              ]
+            }]
+          }] } } } };
         axios.get.mockResolvedValue(resp);
       });
 


### PR DESCRIPTION
Fixes problem in previous PR that updated to use new collection IDs, where an error was thrown if the collection had no granules