### PR TITLE
[CMR-7139] search collectionids

### DIFF
--- a/search/lib/api/wfs.js
+++ b/search/lib/api/wfs.js
@@ -39,7 +39,7 @@ async function getCollections (request, response) {
     const provider = request.params.providerId;
     const params = Object.assign(
       { provider_short_name: provider },
-      await cmr.convertParams(request.query)
+      await cmr.convertParams(provider, request.query)
     );
     const collections = await cmr.findCollections(params);
     if (!collections.length) {
@@ -144,7 +144,7 @@ async function getGranules (request, response) {
   try {
     const cmrParams = Object.assign(
       { provider: providerId },
-      await cmr.convertParams(query)
+      await cmr.convertParams(providerId, query)
     );
     if (collectionId) {
       Object.assign(cmrParams, cmr.stacCollectionToCmrParams(providerId, collectionId));

--- a/search/lib/api/wfs.js
+++ b/search/lib/api/wfs.js
@@ -39,7 +39,7 @@ async function getCollections (request, response) {
     const provider = request.params.providerId;
     const params = Object.assign(
       { provider_short_name: provider },
-      cmr.convertParams(cmr.STAC_SEARCH_PARAMS_CONVERSION_MAP, request.query)
+      await cmr.convertParams(request.query)
     );
     const collections = await cmr.findCollections(params);
     if (!collections.length) {
@@ -144,7 +144,7 @@ async function getGranules (request, response) {
   try {
     const cmrParams = Object.assign(
       { provider: providerId },
-      cmr.convertParams(cmr.STAC_SEARCH_PARAMS_CONVERSION_MAP, query)
+      await cmr.convertParams(query)
     );
     if (collectionId) {
       Object.assign(cmrParams, cmr.stacCollectionToCmrParams(providerId, collectionId));

--- a/search/lib/cmr.js
+++ b/search/lib/cmr.js
@@ -218,7 +218,7 @@ function fromEntries (entries) {
 
 /**
  * Converts STAC parameter to equivalent CMR parameter
- * @param {string} providerId CMR Provider ID 
+ * @param {string} providerId CMR Provider ID
  * @param {string} key The STAC field name
  * @param {string} value The STAC value
  */
@@ -240,7 +240,7 @@ async function convertParam (providerId, key, value) {
 
 /**
  * Converts STAC parameters to CMR parameters
- * @param {string} providerId CMR Provider ID 
+ * @param {string} providerId CMR Provider ID
  * @param {object} params STAC parameters
  */
 async function convertParams (providerId, params = {}) {

--- a/search/tests/cmr/cmr.spec.js
+++ b/search/tests/cmr/cmr.spec.js
@@ -229,7 +229,7 @@ describe('cmr', () => {
         expect(result).toEqual({ polygon: '10,10' });
       });
 
-      it('should convert page_size to limit.', async () => {
+      it('should convert limit to page_size.', async () => {
         const params = {
           limit: 5
         };

--- a/search/tests/cmr/cmr.spec.js
+++ b/search/tests/cmr/cmr.spec.js
@@ -1,6 +1,5 @@
 const axios = require('axios');
 const {
-  STAC_SEARCH_PARAMS_CONVERSION_MAP,
   makeCmrSearchUrl,
   cmrSearch,
   findCollections,
@@ -203,53 +202,46 @@ describe('cmr', () => {
   });
 
   describe('convertParams', () => {
-    it('should create a new set of params based on a conversion Map.', () => {
-      const map = { originalKey: ['key', (v) => v.toUpperCase()] };
-      const original = { originalKey: 'test' };
-      const converted = { key: 'TEST' };
-      expect(convertParams(map, original)).toEqual(converted);
-    });
-
     describe('STAC_SEARCH_PARAMS_CONVERSION_MAP', () => {
-      it('should convert a bbox to bounding_box.', () => {
+      it('should convert a bbox to bounding_box.', async () => {
         const params = {
           bbox: [10, 10, 10, 10]
         };
-        const result = convertParams(STAC_SEARCH_PARAMS_CONVERSION_MAP, params);
+        const result = await convertParams(params);
         expect(result).toEqual({ bounding_box: [10, 10, 10, 10] });
       });
 
-      it('should convert time into temporal.', () => {
+      it('should convert time into temporal.', async () => {
         const params = {
           datetime: '12:34:00pm'
         };
-        const result = convertParams(STAC_SEARCH_PARAMS_CONVERSION_MAP, params);
+        const result = await convertParams(params);
         expect(result).toEqual({ temporal: '12:34:00pm' });
       });
 
-      it('should convert intersects into polygon.', () => {
+      it('should convert intersects into polygon.', async () => {
         const params = {
           intersects: {
             coordinates: [[10, 10], [10, 0], [0, 10]]
           }
         };
-        const result = convertParams(STAC_SEARCH_PARAMS_CONVERSION_MAP, params);
+        const result = await convertParams(params);
         expect(result).toEqual({ polygon: '10,10' });
       });
 
-      it('should convert page_size to limit.', () => {
+      it('should convert page_size to limit.', async () => {
         const params = {
           limit: 5
         };
-        const result = convertParams(STAC_SEARCH_PARAMS_CONVERSION_MAP, params);
+        const result = await convertParams(params);
         expect(result).toEqual({ page_size: 5 });
       });
 
-      it('should convert collection_concept_id to collections', () => {
+      it('should convert collection_concept_id to collections', async () => {
         const params = {
           collections: [1]
         };
-        const result = convertParams(STAC_SEARCH_PARAMS_CONVERSION_MAP, params);
+        const result = await convertParams(params);
         expect(result).toEqual({ collection_concept_id: [1] });
       });
     });

--- a/search/tests/cmr/cmr.spec.js
+++ b/search/tests/cmr/cmr.spec.js
@@ -207,7 +207,7 @@ describe('cmr', () => {
         const params = {
           bbox: [10, 10, 10, 10]
         };
-        const result = await convertParams(params);
+        const result = await convertParams('provider', params);
         expect(result).toEqual({ bounding_box: [10, 10, 10, 10] });
       });
 
@@ -215,7 +215,7 @@ describe('cmr', () => {
         const params = {
           datetime: '12:34:00pm'
         };
-        const result = await convertParams(params);
+        const result = await convertParams('provider', params);
         expect(result).toEqual({ temporal: '12:34:00pm' });
       });
 
@@ -225,7 +225,7 @@ describe('cmr', () => {
             coordinates: [[10, 10], [10, 0], [0, 10]]
           }
         };
-        const result = await convertParams(params);
+        const result = await convertParams('provider', params);
         expect(result).toEqual({ polygon: '10,10' });
       });
 
@@ -233,15 +233,19 @@ describe('cmr', () => {
         const params = {
           limit: 5
         };
-        const result = await convertParams(params);
+        const result = await convertParams('provider', params);
         expect(result).toEqual({ page_size: 5 });
       });
 
-      it('should convert collection_concept_id to collections', async () => {
+      it('should convert collections into collection_concept_id', async () => {
+        axios.get = jest.fn();
+        const cmrResponse = { data: { feed: { entry: [{ id: 1 }] } } };
+        axios.get.mockResolvedValue(cmrResponse);
+
         const params = {
-          collections: [1]
+          collections: ['name.v0']
         };
-        const result = await convertParams(params);
+        const result = await convertParams('provider', params);
         expect(result).toEqual({ collection_concept_id: [1] });
       });
     });


### PR DESCRIPTION
Previous PR #124 added using new Collection IDs of the form `<entry-title>.v<version>` instead of the CMR collection_concept_id, for all endpoints other than /search. 

This PR adds the new collection Ids to /search and updates the convertParam functions to be async.  New collection Ids are translated to collection_concept_id by querying the collection from CMR. A cache is maintained to reduce subsequent calls.