### PR TITLE
[CMR-7139] missing collections

### DIFF
--- a/search/lib/api/provider.js
+++ b/search/lib/api/provider.js
@@ -12,7 +12,7 @@ async function getProvider (request, response) {
     const event = request.apiGateway.event;
 
     // validate that providerId is valid
-    const providerList = await cmr.getProviders();
+    const providerList = await cmr.getProviderList();
     const isProvider = providerList.filter(providerObj => providerObj['provider-id'] === providerId);
     if (isProvider.length === 0) throw new Error(`Provider [${providerId}] not found`);
 
@@ -52,7 +52,7 @@ async function getProvider (request, response) {
 
 async function getProviders (request, response) {
   const event = request.apiGateway.event;
-  const providers = await cmr.getProviders();
+  const providers = await cmr.getProviderList();
   const providerLinks = await Promise.map(providers, async (provider) => {
     return {
       title: provider['short-name'],

--- a/search/lib/api/wfs.js
+++ b/search/lib/api/wfs.js
@@ -98,9 +98,10 @@ async function getCollection (request, response) {
   const collectionId = request.params.collectionId;
 
   try {
+    // convert collection ID to CMR <short_name> and <version>
     const cmrParams = cmr.stacCollectionToCmrParams(providerId, collectionId);
     const collections = await cmr.findCollections(cmrParams);
-
+    // There will only be one collection returned
     const collectionResponse = convert.cmrCollToWFSColl(event, collections[0]);
     // add browse links
     if (process.env.BROWSE_PATH) {
@@ -122,7 +123,6 @@ async function getGranules (request, response) {
   const providerId = request.params.providerId;
   const event = request.apiGateway.event;
   const method = event.httpMethod;
-  logger.debug(`Event: ${JSON.stringify(event)}`);
   logger.info(`${method} ${event.path}`);
 
   let params, fields;

--- a/search/lib/api/wfs.js
+++ b/search/lib/api/wfs.js
@@ -27,7 +27,7 @@ env.BROWSE_PATH = process.env.BROWSE_PATH;
 env.CONFORMANCE_RESPONSE = CONFORMANCE_RESPONSE;
 
 /**
- * Fetch a list of collections from CMR.
+ * Fetch a list of collections from CMR for a provider.
  */
 async function getCollections (request, response) {
   try {
@@ -37,11 +37,7 @@ async function getCollections (request, response) {
     const { currPage, prevResultsLink, nextResultsLink } = generateNavLinks(event);
 
     const provider = request.params.providerId;
-    const params = Object.assign(
-      { provider_short_name: provider },
-      await cmr.convertParams(provider, request.query)
-    );
-    const collections = await cmr.findCollections(params);
+    const collections = await cmr.findCollections({ provider_short_name: provider });
     if (!collections.length) {
       return response.status(400).json('Collections not found');
     }
@@ -82,8 +78,8 @@ async function getCollections (request, response) {
 
 async function createBrowseLinks (event, provider, collectionId) {
   // get all child years
-  const params = cmr.stacCollectionToCmrParams(provider, collectionId);
-  const facets = await cmr.getGranuleTemporalFacets(params);
+  const cmrParams = await cmr.convertParams(provider, { collections: [collectionId] });
+  const facets = await cmr.getGranuleTemporalFacets(cmrParams);
   const path = `/${provider}/collections/${collectionId}`;
   // create catalog link for each year
   const links = facets.years.map(y =>
@@ -102,6 +98,7 @@ async function getCollection (request, response) {
   const collectionId = request.params.collectionId;
 
   const cmrParams = cmr.stacCollectionToCmrParams(providerId, collectionId);
+
   const collections = await cmr.findCollections(cmrParams);
 
   if ((!collections) || (collections.length === 0)) {
@@ -130,37 +127,36 @@ async function getGranules (request, response) {
   logger.debug(`Event: ${JSON.stringify(event)}`);
   logger.info(`${method} ${event.path}`);
 
-  let query, fields;
+  let params, fields;
   if (method === 'GET') {
-    query = stacExtension.prepare(request.query);
+    params = stacExtension.prepare(request.query);
     fields = request.query.fields;
   } else if (method === 'POST') {
-    query = stacExtension.prepare(request.body);
+    params = stacExtension.prepare(request.body);
     fields = request.body.fields;
   } else {
     throw new Error(`Invalid httpMethod ${method}`);
   }
 
   try {
-    const cmrParams = Object.assign(
-      { provider: providerId },
-      await cmr.convertParams(providerId, query)
-    );
+    // CollectionId Path parameter (e.g., /collections/<collectionId>/items vs /search)
     if (collectionId) {
-      Object.assign(cmrParams, cmr.stacCollectionToCmrParams(providerId, collectionId));
+      Object.assign(params, { collections: [collectionId] });
     }
+    // convert STAC params to CMR Params
+    const cmrParams = await cmr.convertParams(providerId, params);
     const granulesResult = await cmr.findGranules(cmrParams);
 
     const featureCollection = await convert.cmrGranulesToStac(event,
       granulesResult.granules,
       parseInt(granulesResult.hits),
-      query);
+      params);
     await assertValid(schemas.items, featureCollection);
 
     const formatted = stacExtension.format(featureCollection,
       {
         fields,
-        context: { searchResult: granulesResult, query }
+        context: { searchResult: granulesResult, query: params }
       });
 
     response.json(formatted);
@@ -183,11 +179,10 @@ async function getGranule (request, response) {
   logger.info(`GET /${providerId}/collections/${collectionId}/items/${conceptId}`);
   const event = request.apiGateway.event;
 
-  const cmrParams = Object.assign(
-    { concept_id: conceptId },
-    cmr.stacCollectionToCmrParams(providerId, collectionId)
-  );
-
+  const cmrParams = {
+    provider_id: providerId,
+    concept_id: conceptId
+  };
   const granules = (await cmr.findGranules(cmrParams)).granules;
   const granuleResponse = await convert.cmrGranuleToStac(event, granules[0]);
   await assertValid(schemas.item, granuleResponse);
@@ -230,7 +225,7 @@ async function getCatalog (request, response) {
   cat.createParent(selfUrl.slice(0, selfUrl.lastIndexOf('/')));
 
   // add browse links
-  const cmrParams = cmr.stacCollectionToCmrParams(providerId, collectionId);
+  const cmrParams = await cmr.convertParams(providerId, { collections: [collectionId] });
   const facets = await cmr.getGranuleTemporalFacets(cmrParams, year, month, day);
   if (day) {
     facets.itemids.forEach(id => cat.addItem(id, providerId, collectionId, id));

--- a/search/lib/cmr.js
+++ b/search/lib/cmr.js
@@ -104,9 +104,12 @@ async function findGranules (params = {}) {
  * @param {string} collectionId The STAC Collection ID
  */
 function stacCollectionToCmrParams (providerId, collectionId) {
-  const collectionIds = collectionId.split('.v');
-  const version = collectionIds.pop();
-  const shortName = collectionIds.join('.');
+  const parts = collectionId.split('.v');
+  if (parts.length < 2) {
+    throw new Error(`Collection ${collectionId} not found for provider ${providerId}`);
+  }
+  const version = parts.pop();
+  const shortName = parts.join('.');
   return {
     provider_id: providerId,
     short_name: shortName,
@@ -127,7 +130,7 @@ async function stacIdToCmrCollectionId (providerId, stacId) {
   const cmrParams = stacCollectionToCmrParams(providerId, stacId);
   const collections = await findCollections(cmrParams);
   if (collections.length === 0) {
-    throw new Error(`Collection {stacId} not found for provider {providerId}`);
+    throw new Error(`Collection ${stacId} not found for provider ${providerId}`);
   } else {
     collectionId = collections[0].id;
     myCache.set(stacId, collectionId, 14400);
@@ -238,7 +241,7 @@ function fromEntries (entries) {
 async function convertParam (providerId, key, value) {
   // Invalid STAC parameter
   if (!Object.keys(STAC_SEARCH_PARAMS_CONVERSION_MAP).includes(key)) {
-    throw Error(`Unsupported parameter ${key}`);
+    throw new Error(`Unsupported parameter ${key}`);
   }
   // If collection parameter need to translate to CMR parameter
   if (key === 'collections') {

--- a/search/lib/cmr.js
+++ b/search/lib/cmr.js
@@ -35,7 +35,8 @@ const DEFAULT_HEADERS = {
  */
 async function cmrSearch (path, params) {
   // should be search path (e.g., granules.json, collections, etc)
-  if (!path || !params) throw new Error('Missing url or parameters');
+  if (!path) throw new Error('Missing url');
+  if (!params) throw new Error('Missing parameters');
   const url = makeCmrSearchUrl(path);
   logger.debug(`CMR Search: ${url} with params: ${JSON.stringify(params)}`);
   return axios.get(url, { params, headers: DEFAULT_HEADERS });

--- a/search/tests/api/provider.spec.js
+++ b/search/tests/api/provider.spec.js
@@ -53,10 +53,10 @@ const expectedProviders = [
 
 describe('getProviders', () => {
   beforeEach(() => {
-    mockFunction(cmr, 'getProviders', Promise.resolve(mockProviderResponse));
+    mockFunction(cmr, 'getProviderList', Promise.resolve(mockProviderResponse));
   });
   afterEach(() => {
-    revertFunction(cmr, 'getProviders');
+    revertFunction(cmr, 'getProviderList');
   });
 
   it('should return an array', async () => {

--- a/search/tests/api/wfs.spec.js
+++ b/search/tests/api/wfs.spec.js
@@ -37,6 +37,7 @@ describe('wfs routes', () => {
     });
     response = createMockResponse();
     mockFunction(cmr, 'findCollections', Promise.resolve(exampleData.cmrColls));
+    mockFunction(cmr, 'convertParams', {});
     mockFunction(cmr, 'findGranules', Promise.resolve({ granules: exampleData.cmrGrans, hits: exampleData.cmrGrans.length }));
     mockFunction(cmr, 'getGranuleTemporalFacets',
       { years: ['2001', '2002'], months: ['05', '06'], days: ['20', '21'], itemids: ['test1'] });
@@ -44,6 +45,7 @@ describe('wfs routes', () => {
 
   afterEach(() => {
     revertFunction(cmr, 'findCollections');
+    revertFunction(cmr, 'convertParams');
     revertFunction(cmr, 'findGranules');
     revertFunction(cmr, 'getCatalog');
     revertFunction(cmr, 'getGranuleTemporalFacets');
@@ -155,7 +157,7 @@ describe('wfs routes', () => {
           },
           {
             rel: 'next',
-            href: 'http://example.com?limit=2&page=2',
+            href: 'http://example.com?limit=2&collections=1&page=2',
             method: 'GET'
           }
         ],
@@ -189,7 +191,7 @@ describe('wfs routes', () => {
           {
             rel: 'prev',
             method: 'GET',
-            href: 'http://example.com?page=1'
+            href: 'http://example.com?page=1&collections=1'
           }
         ],
         features: exampleData.stacGrans
@@ -208,6 +210,11 @@ describe('wfs routes', () => {
     beforeEach(() => {
       process.env.BROWSE_PATH = 'year/month/day';
       request.apiGateway = { event: { headers: { Host: 'example.com' }, queryStringParameters: [] } };
+      mockFunction(cmr, 'convertParams', {});
+    });
+
+    afterEach(() => {
+      revertFunction(cmr, 'convertParams');
     });
 
     it('should return Months catalog given a year catalog', async () => {

--- a/search/tests/api/wfs.spec.js
+++ b/search/tests/api/wfs.spec.js
@@ -31,7 +31,7 @@ describe('wfs routes', () => {
     request = createRequest({
       params: {
         providerId: 'LPDAAC',
-        collectionId: '1',
+        collectionId: '1.v1',
         itemId: '1'
       }
     });
@@ -97,7 +97,7 @@ describe('wfs routes', () => {
         await getCollection(request, response);
         expect(response.getData()).toEqual({
           status: 404,
-          json: 'Collection [1] not found for provider [LPDAAC]'
+          json: 'Collection 1.v1 not found for provider LPDAAC'
         });
       });
     });
@@ -157,7 +157,7 @@ describe('wfs routes', () => {
           },
           {
             rel: 'next',
-            href: 'http://example.com?limit=2&collections=1&page=2',
+            href: 'http://example.com?limit=2&collections=1.v1&page=2',
             method: 'GET'
           }
         ],
@@ -191,7 +191,7 @@ describe('wfs routes', () => {
           {
             rel: 'prev',
             method: 'GET',
-            href: 'http://example.com?page=1&collections=1'
+            href: 'http://example.com?page=1&collections=1.v1'
           }
         ],
         features: exampleData.stacGrans
@@ -224,7 +224,7 @@ describe('wfs routes', () => {
       await getCatalog(request, response);
       const cat = response.getData().json;
       expect(cat.links.length).toEqual(5);
-      expect(cat.id).toEqual('1-2001');
+      expect(cat.id).toEqual('1.v1-2001');
     });
 
     it('should return Days catalog given a Month catalog', async () => {
@@ -234,7 +234,7 @@ describe('wfs routes', () => {
       await getCatalog(request, response);
       const cat = response.getData().json;
       expect(cat.links.length).toEqual(5);
-      expect(cat.id).toEqual('1-2001-05');
+      expect(cat.id).toEqual('1.v1-2001-05');
     });
 
     it('should return Item catalog given a Day catalog', async () => {
@@ -244,7 +244,7 @@ describe('wfs routes', () => {
       await getCatalog(request, response);
       const cat = response.getData().json;
       expect(cat.links.length).toEqual(4);
-      expect(cat.id).toEqual('1-2001-05-20');
+      expect(cat.id).toEqual('1.v1-2001-05-20');
     });
   });
 });

--- a/search/tests/cmr/cmr.spec.js
+++ b/search/tests/cmr/cmr.spec.js
@@ -39,7 +39,7 @@ describe('cmr', () => {
     });
 
     it('should take in a url and a params object', async () => {
-      const error = new Error('Missing url or parameters');
+      const error = new Error('Missing url');
       expect.assertions(1);
       try {
         await cmrSearch();

--- a/search/tests/cmr/cmr.spec.js
+++ b/search/tests/cmr/cmr.spec.js
@@ -1,11 +1,9 @@
 const axios = require('axios');
 const {
-  makeCmrSearchUrl,
   cmrSearch,
   findCollections,
   findGranules,
   convertParams,
-  fromEntries,
   getFacetParams,
   getGranuleTemporalFacets
 } = require('../../lib/cmr');
@@ -21,31 +19,10 @@ afterAll(() => {
 });
 
 describe('cmr', () => {
-  let path, params;
+  let params;
 
   beforeEach(() => {
-    path = 'path/to/resource';
     params = { param: 'test' };
-  });
-
-  describe('makeCmrSearchUrl', () => {
-    it('should exist', () => {
-      expect(makeCmrSearchUrl).toBeDefined();
-    });
-    it('should create a url with zero params.', () => {
-      expect(makeCmrSearchUrl())
-        .toBe('https://cmr.earthdata.nasa.gov/search');
-    });
-
-    it('should create a url with path and no query params', () => {
-      expect(makeCmrSearchUrl(path))
-        .toBe('https://cmr.earthdata.nasa.gov/search/path/to/resource');
-    });
-
-    it('should create a url with a path and query params', () => {
-      expect(makeCmrSearchUrl(path, params))
-        .toBe('https://cmr.earthdata.nasa.gov/search/path/to/resource?param=test');
-    });
   });
 
   describe('cmrSearch', () => {
@@ -72,9 +49,9 @@ describe('cmr', () => {
     });
 
     it('should return a cmr collection', async () => {
-      cmrSearch('https://example.com', { });
+      cmrSearch('test-endpoint', { });
       expect(axios.get.mock.calls.length).toBe(1);
-      expect(axios.get.mock.calls[0][0]).toBe('https://example.com');
+      expect(axios.get.mock.calls[0][0]).toBe('https://cmr.earthdata.nasa.gov/search/test-endpoint');
       expect(axios.get.mock.calls[0][1]).toEqual({ headers: { 'Client-Id': 'cmr-stac-api-proxy' }, params: { } });
     });
   });
@@ -208,7 +185,7 @@ describe('cmr', () => {
           bbox: [10, 10, 10, 10]
         };
         const result = await convertParams('provider', params);
-        expect(result).toEqual({ bounding_box: [10, 10, 10, 10] });
+        expect(result).toEqual({ provider: 'provider', bounding_box: [10, 10, 10, 10] });
       });
 
       it('should convert time into temporal.', async () => {
@@ -216,7 +193,7 @@ describe('cmr', () => {
           datetime: '12:34:00pm'
         };
         const result = await convertParams('provider', params);
-        expect(result).toEqual({ temporal: '12:34:00pm' });
+        expect(result).toEqual({ provider: 'provider', temporal: '12:34:00pm' });
       });
 
       it('should convert intersects into polygon.', async () => {
@@ -226,7 +203,7 @@ describe('cmr', () => {
           }
         };
         const result = await convertParams('provider', params);
-        expect(result).toEqual({ polygon: '10,10' });
+        expect(result).toEqual({ provider: 'provider', polygon: '10,10' });
       });
 
       it('should convert limit to page_size.', async () => {
@@ -234,7 +211,7 @@ describe('cmr', () => {
           limit: 5
         };
         const result = await convertParams('provider', params);
-        expect(result).toEqual({ page_size: 5 });
+        expect(result).toEqual({ provider: 'provider', page_size: 5 });
       });
 
       it('should convert collections into collection_concept_id', async () => {
@@ -246,7 +223,7 @@ describe('cmr', () => {
           collections: ['name.v0']
         };
         const result = await convertParams('provider', params);
-        expect(result).toEqual({ collection_concept_id: [1] });
+        expect(result).toEqual({ provider: 'provider', collection_concept_id: [1] });
       });
     });
   });
@@ -329,21 +306,6 @@ describe('cmr', () => {
         const facets = await getGranuleTemporalFacets(cmrParams, '2001', '05');
         expect(Object.keys(facets['days']).length).toEqual(3);
       });
-    });
-  });
-
-  describe('fromEntries', () => {
-    it('should exist', () => {
-      expect(fromEntries).toBeDefined();
-    });
-
-    it('should accept a parameter', () => {
-      expect(() => fromEntries()).toThrow();
-    });
-
-    it('should return an object made of entries', () => {
-      expect(fromEntries([['a', 'd'], ['b', 'e'], ['c', 'f']]))
-        .toEqual({ a: 'd', b: 'e', c: 'f' });
     });
   });
 });


### PR DESCRIPTION
Missing collections, either in the path parameter `/collections/NoSuchCollection` or when searching `/search?collections[]=NoSuchCollection` will both throw a 404.

Was going to ignore invalid collections when searching at `/search` but on further thought this seemed like arbitrary behavior and would not be clear to a user. If user specifies 2+ collections, you can safely ignore one and only get back matches on the other.

But what if the user provides a single non-existent collection? If ignored, this would return all matching granules across all collections.

It seems better for the user to raise a 404 in both cases.

This PR also cleans up the CMR module and consolidates some functions.