### PR TITLE
[CMR-7139] fixes to collection ids, pagination, and error responses

### DIFF
--- a/search/lib/api/provider.js
+++ b/search/lib/api/provider.js
@@ -30,9 +30,6 @@ async function getProvider (request, response) {
       providerHoldings = await cmr.findCollections(params);
       id = 'id';
       rootCatalogName = 'CMR-CLOUDSTAC Root catalog';
-      if (!providerHoldings.length) {
-        return response.status(400).json(`Cloud holding collections not found for provider [${providerId}].`);
-      }
     } else {
       providerHoldings = await cmr.getProvider(providerId);
       id = 'concept-id';

--- a/search/lib/api/provider.js
+++ b/search/lib/api/provider.js
@@ -16,7 +16,6 @@ async function getProvider (request, response) {
     const isProvider = providerList.filter(providerObj => providerObj['provider-id'] === providerId);
     if (isProvider.length === 0) throw new Error(`Provider [${providerId}] not found`);
 
-    let rootCatalogName = 'CMR-STAC Root catalog';
     // Need to page through all the cloud collections. One page at a time, 10 collections in each page.
     const { currPage, prevResultsLink, nextResultsLink } = generateNavLinks(event);
 
@@ -26,7 +25,6 @@ async function getProvider (request, response) {
     if (settings.cmrStacRelativeRootUrl === '/cloudstac') {
       // Query params to get cloud holdings for the provider.
       Object.assign(cmrParams, { tag_key: 'gov.nasa.earthdatacloud.s3' });
-      rootCatalogName = 'CMR-CLOUDSTAC Root catalog';
     }
     const providerHoldings = await cmr.findCollections(cmrParams);
 
@@ -34,7 +32,7 @@ async function getProvider (request, response) {
       wfs.createLink('self', generateAppUrl(event, `/${providerId}`),
         'Provider catalog'),
       wfs.createLink('root', generateAppUrl(event, '/'),
-        `${rootCatalogName}`),
+        'Root catalog'),
       wfs.createLink('collections', generateAppUrl(event, `/${providerId}/collections`),
         'Provider Collections'),
       wfs.createLink('search', generateAppUrl(event, `/${providerId}/search`),

--- a/search/lib/api/provider.js
+++ b/search/lib/api/provider.js
@@ -37,9 +37,6 @@ async function getProvider (request, response) {
       providerHoldings = await cmr.getProvider(providerId);
       id = 'concept-id';
       rootCatalogName = 'CMR-STAC Root catalog';
-      if (!providerHoldings.length) {
-        return response.status(400).json(`Collections not found for provider [${providerId}].`);
-      }
     }
 
     const links = [

--- a/search/lib/api/stac.js
+++ b/search/lib/api/stac.js
@@ -1,13 +1,13 @@
 const express = require('express');
 
 const { makeAsyncHandler } = require('../util');
-const { getGranules } = require('./wfs');
+const { getItems } = require('./wfs');
 
 /**
  * Primary search function for STAC.
  */
 async function search (request, response) {
-  return getGranules(request, response);
+  return getItems(request, response);
 }
 
 const routes = express.Router();

--- a/search/lib/api/wfs.js
+++ b/search/lib/api/wfs.js
@@ -118,7 +118,6 @@ async function getCollection (request, response) {
     const collectionResponse = convert.cmrCollToWFSColl(event, collections[0]);
     // add browse links
     if (process.env.BROWSE_PATH) {
-      delete cmrParams.tag_key;
       const facets = await cmr.getGranuleTemporalFacets(cmrParams);
       const path = `/${providerId}/collections/${collectionId}`;
       // create catalog link for each year

--- a/search/lib/api/wfs.js
+++ b/search/lib/api/wfs.js
@@ -38,14 +38,13 @@ async function getCollections (request, response) {
 
     const provider = request.params.providerId;
 
-    let params, errMsg, rootName, description;
+    let params, rootName, description;
     if (settings.cmrStacRelativeRootUrl === '/cloudstac') {
       params = Object.assign(
         { tag_key: 'gov.nasa.earthdatacloud.s3' },
         // request.query is used for pagination
         await cmr.convertParams(provider, request.query)
       );
-      errMsg = 'Cloud holding collections not found';
       rootName = 'CMR-CLOUDSTAC Root';
       description = `All cloud holding collections provided by ${provider}`;
     } else {
@@ -53,15 +52,11 @@ async function getCollections (request, response) {
         // request.query is used for pagination
         await cmr.convertParams(provider, request.query)
       );
-      errMsg = 'Collections not found';
       rootName = 'CMR-STAC Root';
       description = `All collections provided by ${provider}`;
     }
 
     const collections = await cmr.findCollections(params);
-    if (!collections.length) {
-      return response.status(400).json(`${errMsg}`);
-    }
 
     const collectionsResponse = {
       id: provider,

--- a/search/lib/api/wfs.js
+++ b/search/lib/api/wfs.js
@@ -118,6 +118,7 @@ async function getCollection (request, response) {
     const collectionResponse = convert.cmrCollToWFSColl(event, collections[0]);
     // add browse links
     if (process.env.BROWSE_PATH) {
+      delete cmrParams.tag_key;
       const facets = await cmr.getGranuleTemporalFacets(cmrParams);
       const path = `/${providerId}/collections/${collectionId}`;
       // create catalog link for each year

--- a/search/lib/api/wfs.js
+++ b/search/lib/api/wfs.js
@@ -175,7 +175,6 @@ function extractParams (request) {
   if (method === 'GET') {
     const arrayParameters = ['collections', 'ids'];
     const multiParams = event.multiValueQueryStringParameters || {};
-    console.log(`multiParams = ${multiParams}`);
     const _params = Object.entries(multiParams).map(([k, v]) => {
       if (arrayParameters.includes(k)) {
         return [k, v];

--- a/search/lib/cmr.js
+++ b/search/lib/cmr.js
@@ -273,6 +273,9 @@ async function convertParam (providerId, key, value) {
   if (!Object.keys(STAC_SEARCH_PARAMS_CONVERSION_MAP).includes(key)) {
     throw new Error(`Unsupported parameter ${key}`);
   }
+  if (key === 'limit' && value > settings.maxLimit) {
+    throw new Error(`Maximum limit parameter of ${settings.maxLimit}`);
+  }
   // If collection parameter need to translate to CMR parameter
   if (key === 'collections') {
     // async map to do collection ID conversions in parallel

--- a/search/lib/cmr.js
+++ b/search/lib/cmr.js
@@ -305,7 +305,6 @@ async function convertParams (providerId, params = {}) {
     // async map to do all param conversions in parallel
     const converted = await Promise.reduce(Object.entries(params), async (result, [k, v]) => {
       const param = await convertParam(providerId, k, v);
-      console.log(`param = ${JSON.stringify(param)} ${k} ${v}`)
       if (param.length === 2) {
         result.push(param);
       }

--- a/search/lib/cmr.js
+++ b/search/lib/cmr.js
@@ -163,7 +163,7 @@ async function stacIdToCmrCollectionId (providerId, stacId) {
     return null;
   } else {
     collectionId = collections[0].id;
-    myCache.set(stacId, collectionId, 14400);
+    myCache.set(stacId, collectionId, settings.cacheTtl);
     return collectionId;
   }
 }
@@ -180,7 +180,7 @@ async function cmrCollectionIdToStacId (collectionId) {
   }
   const collections = await findCollections({ concept_id: collectionId });
   stacId = `${collections[0].short_name}.v${collections[0].version_id}`;
-  myCache.set(collectionId, stacId, 14400);
+  myCache.set(collectionId, stacId, settings.cacheTtl);
   return stacId;
 }
 

--- a/search/lib/cmr.js
+++ b/search/lib/cmr.js
@@ -204,7 +204,7 @@ function getFacetParams (year, month, day) {
 }
 
 async function getGranuleTemporalFacets (params = {}, year, month, day) {
-  const cmrParams = Object.assign(params, getFacetParams(year, month, day));
+  const { tag_key, ...cmrParams } = Object.assign(params, getFacetParams(year, month, day));
 
   const facets = {
     years: [],

--- a/search/lib/settings.js
+++ b/search/lib/settings.js
@@ -56,6 +56,7 @@ function getSettings () {
     settings.cmrProviderHost = process.env.CMR_PROVIDER_HOST || 'cmr.earthdata.nasa.gov/ingest/providers';
     settings.cmrSearchProtocol = process.env.CMR_SEARCH_PROTOCOL || 'https';
     settings.cacheTtl = process.env.CMR_STAC_CACHE_TTL || 14400;
+    settings.maxLimit = process.env.CMR_STAC_MAX_LIMIT || 500;
 
     settings.throwCmrConvertParamErrors = process.env.THROW_CMR_CONVERT_PARAM_ERRORS === 'true';
 

--- a/search/lib/settings.js
+++ b/search/lib/settings.js
@@ -55,6 +55,7 @@ function getSettings () {
     settings.cmrSearchHost = process.env.CMR_SEARCH_HOST || 'cmr.earthdata.nasa.gov/search';
     settings.cmrProviderHost = process.env.CMR_PROVIDER_HOST || 'cmr.earthdata.nasa.gov/ingest/providers';
     settings.cmrSearchProtocol = process.env.CMR_SEARCH_PROTOCOL || 'https';
+    settings.cacheTtl = process.env.CMR_STAC_CACHE_TTL || 14400;
 
     settings.throwCmrConvertParamErrors = process.env.THROW_CMR_CONVERT_PARAM_ERRORS === 'true';
 

--- a/search/lib/util/index.js
+++ b/search/lib/util/index.js
@@ -66,7 +66,7 @@ function generateAppUrl (event, path, queryParams = null) {
 }
 
 function generateSelfUrl (event) {
-  return generateAppUrlWithoutRelativeRoot(event, event.path, event.queryStringParameters);
+  return generateAppUrlWithoutRelativeRoot(event, event.path, event.multiValueQueryStringParameters);
 }
 
 function makeAsyncHandler (fn) {
@@ -100,12 +100,12 @@ const extractParam = (queryStringParams, param, defaultVal = null) => {
 };
 
 function generateNavLinks (event) {
-  const currPage = parseInt(extractParam(event.queryStringParameters, 'page', '1'), 10);
+  const currPage = parseInt(extractParam(event.multiValueQueryStringParameters, 'page', '1'), 10);
   const nextPage = currPage + 1;
   const prevPage = currPage - 1;
-  const newParams = { ...event.queryStringParameters } || {};
+  const newParams = { ...event.multiValueQueryStringParameters } || {};
   newParams.page = nextPage;
-  const newPrevParams = { ...event.queryStringParameters } || {};
+  const newPrevParams = { ...event.multiValueQueryStringParameters } || {};
   newPrevParams.page = prevPage;
   const prevResultsLink = generateAppUrlWithoutRelativeRoot(event, event.path, newPrevParams);
   const nextResultsLink = generateAppUrlWithoutRelativeRoot(event, event.path, newParams);

--- a/search/serverless.yml
+++ b/search/serverless.yml
@@ -20,7 +20,7 @@ functions:
   search-api:
     name: cmr-stac-${opt:stage}
     handler: lib/application.handler
-    timeout: 10
+    timeout: 6
     events:
       - alb:
           listenerArn: ${cf:${opt:stage}.servicesLbListenerArn}

--- a/search/tests/api/provider.spec.js
+++ b/search/tests/api/provider.spec.js
@@ -136,7 +136,7 @@ describe('getProvider', () => {
           {
             rel: 'root',
             href: 'http://example.com/stac/',
-            title: 'CMR-STAC Root catalog',
+            title: 'Root catalog',
             type: 'application/json'
           },
           {
@@ -190,7 +190,7 @@ describe('getProvider', () => {
           {
             rel: 'root',
             href: 'http://example.com/cloudstac/',
-            title: 'CMR-CLOUDSTAC Root catalog',
+            title: 'Root catalog',
             type: 'application/json'
           },
           {

--- a/search/tests/api/stac.spec.js
+++ b/search/tests/api/stac.spec.js
@@ -96,7 +96,9 @@ describe('STAC Search Params', () => {
     it('should query with range when given a single datetime', async () => {
       request = createRequest({
         params: { providerId: 'LPDAAC' },
-        query: { datetime: '2020-11-02T00:00:00Z' }
+        apiGateway: {
+          event: { httpMethod: 'GET', multiValueQueryStringParameters: { datetime: ['2020-11-02T00:00:00Z'] } }
+        }
       });
 
       await search(request, response);
@@ -115,7 +117,9 @@ describe('STAC Search Params', () => {
     it('query using a range when given a range datetime, comma delimited', async () => {
       request = createRequest({
         params: { providerId: 'LPDAAC' },
-        query: { datetime: '2019-02-01T00:00:00Z,2019-05-05T00:30:00Z' }
+        apiGateway: {
+          event: { httpMethod: 'GET', multiValueQueryStringParameters: { datetime: ['2019-02-01T00:00:00Z,2019-05-05T00:30:00Z'] } }
+        }
       });
 
       await search(request, response);
@@ -134,7 +138,9 @@ describe('STAC Search Params', () => {
     it('query using a range when given a range datetime, slash delimited', async () => {
       request = createRequest({
         params: { providerId: 'LPDAAC' },
-        query: { datetime: '2019-02-01T00:00:00Z/2019-05-05T00:30:00Z' }
+        apiGateway: {
+          event: { httpMethod: 'GET', multiValueQueryStringParameters: { datetime: ['2019-02-01T00:00:00Z/2019-05-05T00:30:00Z'] } }
+        }
       });
 
       await search(request, response);
@@ -153,7 +159,9 @@ describe('STAC Search Params', () => {
     it('should query with a time given a time', async () => {
       request = createRequest({
         params: { providerId: 'LPDAAC' },
-        query: { datetime: '12:15:09pm' }
+        apiGateway: {
+          event: { httpMethod: 'GET', multiValueQueryStringParameters: { datetime: ['12:15:09pm'] } }
+        }
       });
 
       await search(request, response);
@@ -172,7 +180,9 @@ describe('STAC Search Params', () => {
     it('should query with range when given a single date', async () => {
       request = createRequest({
         params: { providerId: 'LPDAAC' },
-        query: { datetime: '2020-10-01' }
+        apiGateway: {
+          event: { httpMethod: 'GET', multiValueQueryStringParameters: { datetime: ['2020-10-01'] } }
+        }
       });
 
       await search(request, response);
@@ -191,7 +201,9 @@ describe('STAC Search Params', () => {
     it('should query with range when given a date range, comma delimited', async () => {
       request = createRequest({
         params: { providerId: 'LPDAAC' },
-        query: { datetime: '2020-09-03,2020-10-26' }
+        apiGateway: {
+          event: { httpMethod: 'GET', multiValueQueryStringParameters: { datetime: ['2020-09-03,2020-10-26'] } }
+        }
       });
 
       await search(request, response);
@@ -210,7 +222,9 @@ describe('STAC Search Params', () => {
     it('should query with range when given a date range, slash delimited', async () => {
       request = createRequest({
         params: { providerId: 'LPDAAC' },
-        query: { datetime: '2020-09-03/2020-10-26' }
+        apiGateway: {
+          event: { httpMethod: 'GET', multiValueQueryStringParameters: { datetime: ['2020-09-03/2020-10-26'] } }
+        }
       });
 
       await search(request, response);

--- a/search/tests/convert/granules.spec.js
+++ b/search/tests/convert/granules.spec.js
@@ -237,7 +237,7 @@ describe('granuleToItem', () => {
     const cmrGran = exampleData.examplesByName.lancemodisCmrGran;
     const expectedStacGran = exampleData.examplesByName.lancemodisStacGran;
 
-    const event = { headers: { Host: 'example.com' }, queryStringParameters: [] };
+    const event = { headers: { Host: 'example.com' }, multiValueQueryStringParameters: [] };
 
     it('should return a FeatureGeoJSON from a cmrGran', async () => {
       const stacItem = await cmrGranuleToStac(event, cmrGran);


### PR DESCRIPTION
This PR contains several fixes
- errors are no longer thrown when no collections are found for a provider, instead there are just no links from the catalog, and an empty array at the /collections endpoint
- Invalid collections throw error at the /collections/<collectionId> and subsequent endpoints, but collections provided to the `collections` parameter at /search do not throw an error, they just won't return any results for that collection
- `collections` and `ids` can not be provided multiple times in GET requests (CMR-7140)
- provider catalog pagination when more than 10 collections (CMR-7164)...this was set up to work with the /cloudstac endpoint but not /stac. Both now share the same code for fetching collections