### PR TITLE
CMR-7167: Removed the hardcoded pageSize in getProvider and getCollections

### DIFF
--- a/search/lib/api/provider.js
+++ b/search/lib/api/provider.js
@@ -9,7 +9,7 @@ async function getProvider (request, response) {
   try {
     const providerId = request.params.providerId;
     logger.info(`GET /${providerId}`);
-    const pageSize = request.query.limit || 10;
+    const pageSize = Number(request.query.limit || 10);
     const event = request.apiGateway.event;
 
     // validate that providerId is valid
@@ -63,7 +63,7 @@ async function getProvider (request, response) {
       });
     }
 
-    if (providerHoldings.length === Number(pageSize)) {
+    if (providerHoldings.length === pageSize) {
       provider.links.push({
         rel: 'next',
         href: nextResultsLink

--- a/search/lib/api/provider.js
+++ b/search/lib/api/provider.js
@@ -9,6 +9,7 @@ async function getProvider (request, response) {
   try {
     const providerId = request.params.providerId;
     logger.info(`GET /${providerId}`);
+    const pageSize = request.query.limit || 10;
     const event = request.apiGateway.event;
 
     // validate that providerId is valid
@@ -62,7 +63,7 @@ async function getProvider (request, response) {
       });
     }
 
-    if (providerHoldings.length === 10) {
+    if (providerHoldings.length === Number(pageSize)) {
       provider.links.push({
         rel: 'next',
         href: nextResultsLink

--- a/search/tests/api/provider.spec.js
+++ b/search/tests/api/provider.spec.js
@@ -207,17 +207,36 @@ describe('getProvider', () => {
           }
         ]
       };
+
+      const expectedResponse2 = {
+        id: 'GHRC_DAAC',
+        title: 'GHRC_DAAC',
+        description: 'Root catalog for GHRC_DAAC',
+        stac_version: settings.stac.version,
+        links: [
+          {
+            "rel": "next",
+            "href": "http://example.com?page=2" 
+          }
+        ]
+      };
       const request = createRequest({
         params: {
           providerId: 'GHRC_DAAC'
+        },
+        query: {
+          limit: 1
         }
       });
       const response = createMockResponse();
       await getProvider(request, response);
       const dat = response.getData();
 
+      const savedLinks = dat.json.links;
       dat.json.links = dat.json.links.slice(0, 4);
       response.expect(expectedResponse);
+      dat.json.links = savedLinks.slice(5, 6);
+      response.expect(expectedResponse2);
     });
   });
 });

--- a/search/tests/api/wfs.spec.js
+++ b/search/tests/api/wfs.spec.js
@@ -228,7 +228,7 @@ describe('wfs routes', () => {
             },
             {
               rel: 'next',
-              href: 'http://example.com?limit=2&collections=1.v1&page=2',
+              href: 'http://example.com?limit=2&page=2',
               method: 'GET'
             }
           ],
@@ -261,7 +261,7 @@ describe('wfs routes', () => {
             {
               rel: 'prev',
               method: 'GET',
-              href: 'http://example.com?page=1&collections=1.v1'
+              href: 'http://example.com?page=1'
             }
           ],
           features: exampleData.stacGrans
@@ -329,7 +329,7 @@ describe('wfs routes', () => {
             },
             {
               rel: 'next',
-              href: 'http://example.com?limit=2&collections=1.v1&page=2',
+              href: 'http://example.com?limit=2&page=2',
               method: 'GET'
             }
           ],
@@ -362,7 +362,7 @@ describe('wfs routes', () => {
             {
               rel: 'prev',
               method: 'GET',
-              href: 'http://example.com?page=1&collections=1.v1'
+              href: 'http://example.com?page=1'
             }
           ],
           features: exampleData.cloudstacGrans


### PR DESCRIPTION
This is to fix the pagination next link for CMR-7167. 
Also included fix for CMR-7161: Remove the artificially added query parameter "collections" in page links, in the case of /stac/GHRC_DAAC/collections/lislip.v4/items?limit=1 when <collectionId> appears in the URL. 