### PR TITLE
revert accepting multiple parameters via GET

### DIFF
--- a/search/lib/api/wfs.js
+++ b/search/lib/api/wfs.js
@@ -170,16 +170,7 @@ function extractParams (request) {
 
   let params;
   if (method === 'GET') {
-    const arrayParameters = ['collections', 'ids'];
-    const multiParams = event.multiValueQueryStringParameters || {};
-    const _params = Object.entries(multiParams).map(([k, v]) => {
-      if (arrayParameters.includes(k)) {
-        return [k, v];
-      } else {
-        return [k, v[0]];
-      }
-    });
-    params = stacExtension.prepare(Object.fromEntries(_params));
+    params = stacExtension.prepare(request.query);
   } else if (method === 'POST') {
     params = stacExtension.prepare(request.body);
   } else {
@@ -205,12 +196,12 @@ async function getItems (request, response) {
           .status(404)
           .json(`Collection [${collectionId}] not found for provider [${providerId}]`);
       } else {
-        //collections param not allowed.
-        //when the search is already on a specific collectionId.
+        // collections param not allowed.
+        // when the search is already on a specific collectionId.
         if (params.collections) {
           return response
-          .status(404)
-          .json(`Can not have collections param when there is collectionId [${collectionId}] specified.`);
+            .status(404)
+            .json(`Can not have collections param when there is collectionId [${collectionId}] specified.`);
         }
         params.collections = [collectionId];
       }
@@ -256,7 +247,7 @@ async function getItems (request, response) {
     }
 
     if (collectionId) {
-      //remove the params.collections added.
+      // remove the params.collections added.
       delete params.collections;
     }
 

--- a/search/lib/util/index.js
+++ b/search/lib/util/index.js
@@ -66,7 +66,7 @@ function generateAppUrl (event, path, queryParams = null) {
 }
 
 function generateSelfUrl (event) {
-  return generateAppUrlWithoutRelativeRoot(event, event.path, event.multiValueQueryStringParameters);
+  return generateAppUrlWithoutRelativeRoot(event, event.path, event.queryStringParameters);
 }
 
 function makeAsyncHandler (fn) {
@@ -100,12 +100,12 @@ const extractParam = (queryStringParams, param, defaultVal = null) => {
 };
 
 function generateNavLinks (event) {
-  const currPage = parseInt(extractParam(event.multiValueQueryStringParameters, 'page', '1'), 10);
+  const currPage = parseInt(extractParam(event.queryStringParameters, 'page', '1'), 10);
   const nextPage = currPage + 1;
   const prevPage = currPage - 1;
-  const newParams = { ...event.multiValueQueryStringParameters } || {};
+  const newParams = { ...event.queryStringParameters } || {};
   newParams.page = nextPage;
-  const newPrevParams = { ...event.multiValueQueryStringParameters } || {};
+  const newPrevParams = { ...event.queryStringParameters } || {};
   newPrevParams.page = prevPage;
   const prevResultsLink = generateAppUrlWithoutRelativeRoot(event, event.path, newPrevParams);
   const nextResultsLink = generateAppUrlWithoutRelativeRoot(event, event.path, newParams);

--- a/search/tests/api/provider.spec.js
+++ b/search/tests/api/provider.spec.js
@@ -215,8 +215,8 @@ describe('getProvider', () => {
         stac_version: settings.stac.version,
         links: [
           {
-            "rel": "next",
-            "href": "http://example.com?page=2" 
+            rel: 'next',
+            href: 'http://example.com?page=2'
           }
         ]
       };

--- a/search/tests/api/stac.spec.js
+++ b/search/tests/api/stac.spec.js
@@ -96,6 +96,7 @@ describe('STAC Search Params', () => {
     it('should query with range when given a single datetime', async () => {
       request = createRequest({
         params: { providerId: 'LPDAAC' },
+        query: { datetime: '2020-11-02T00:00:00Z' },
         apiGateway: {
           event: { httpMethod: 'GET', multiValueQueryStringParameters: { datetime: ['2020-11-02T00:00:00Z'] } }
         }
@@ -117,6 +118,7 @@ describe('STAC Search Params', () => {
     it('query using a range when given a range datetime, comma delimited', async () => {
       request = createRequest({
         params: { providerId: 'LPDAAC' },
+        query: { datetime: '2019-02-01T00:00:00Z,2019-05-05T00:30:00Z' },
         apiGateway: {
           event: { httpMethod: 'GET', multiValueQueryStringParameters: { datetime: ['2019-02-01T00:00:00Z,2019-05-05T00:30:00Z'] } }
         }
@@ -138,6 +140,7 @@ describe('STAC Search Params', () => {
     it('query using a range when given a range datetime, slash delimited', async () => {
       request = createRequest({
         params: { providerId: 'LPDAAC' },
+        query: { datetime: '2019-02-01T00:00:00Z/2019-05-05T00:30:00Z' },
         apiGateway: {
           event: { httpMethod: 'GET', multiValueQueryStringParameters: { datetime: ['2019-02-01T00:00:00Z/2019-05-05T00:30:00Z'] } }
         }
@@ -159,6 +162,7 @@ describe('STAC Search Params', () => {
     it('should query with a time given a time', async () => {
       request = createRequest({
         params: { providerId: 'LPDAAC' },
+        query: { datetime: '12:15:09pm' },
         apiGateway: {
           event: { httpMethod: 'GET', multiValueQueryStringParameters: { datetime: ['12:15:09pm'] } }
         }
@@ -180,6 +184,7 @@ describe('STAC Search Params', () => {
     it('should query with range when given a single date', async () => {
       request = createRequest({
         params: { providerId: 'LPDAAC' },
+        query: { datetime: '2020-10-01' },
         apiGateway: {
           event: { httpMethod: 'GET', multiValueQueryStringParameters: { datetime: ['2020-10-01'] } }
         }
@@ -201,6 +206,7 @@ describe('STAC Search Params', () => {
     it('should query with range when given a date range, comma delimited', async () => {
       request = createRequest({
         params: { providerId: 'LPDAAC' },
+        query: { datetime: '2020-09-03,2020-10-26' },
         apiGateway: {
           event: { httpMethod: 'GET', multiValueQueryStringParameters: { datetime: ['2020-09-03,2020-10-26'] } }
         }
@@ -222,6 +228,7 @@ describe('STAC Search Params', () => {
     it('should query with range when given a date range, slash delimited', async () => {
       request = createRequest({
         params: { providerId: 'LPDAAC' },
+        query: { datetime: '2020-09-03/2020-10-26' },
         apiGateway: {
           event: { httpMethod: 'GET', multiValueQueryStringParameters: { datetime: ['2020-09-03/2020-10-26'] } }
         }

--- a/search/tests/api/wfs.spec.js
+++ b/search/tests/api/wfs.spec.js
@@ -205,6 +205,8 @@ describe('wfs routes', () => {
       it('should generate a item collection response with a next link.', async () => {
         request.apiGateway.event.multiValueQueryStringParameters = { limit: [2] };
         request.apiGateway.event.httpMethod = 'GET';
+        request.apiGateway.event.queryStringParameters = { limit: 2 };
+        request.query.limit = 2;
         mockFunction(cmr, 'findGranules', Promise.resolve({ granules: exampleData.cmrGrans, hits: 10 }));
         await getItems(request, response);
         response.expect({
@@ -237,6 +239,8 @@ describe('wfs routes', () => {
       });
 
       it('should generate an item collection response with a prev link.', async () => {
+        request.apiGateway.event.queryStringParameters = { page: 2 };
+        request.query.page = 2;
         request.apiGateway.event.multiValueQueryStringParameters = { page: [2] };
         await getItems(request, response);
         response.expect({
@@ -306,6 +310,8 @@ describe('wfs routes', () => {
       it('should generate a item collection response with a next link.', async () => {
         request.apiGateway.event.multiValueQueryStringParameters = { limit: [2] };
         request.apiGateway.event.httpMethod = 'GET';
+        request.apiGateway.event.queryStringParameters = { limit: 2 };
+        request.query.limit = 2;
         mockFunction(cmr, 'findGranules', Promise.resolve({ granules: exampleData.cmrGrans, hits: 10 }));
         await getItems(request, response);
         response.expect({
@@ -338,6 +344,8 @@ describe('wfs routes', () => {
       });
 
       it('should generate an item collection response with a prev link.', async () => {
+        request.apiGateway.event.queryStringParameters = { page: 2 };
+        request.query.page = 2;
         request.apiGateway.event.multiValueQueryStringParameters = { page: [2] };
         await getItems(request, response);
         response.expect({


### PR DESCRIPTION
Reverts CMR-7140 since using multiValueQueryStringParameters requires enabling multi-value-headers when using a load balancer (which we are)....and enabling it seems to break all GET requests.

Will have to figure out issue with that prior to adding back in multi-value parameter support.