### PR TITLE
CMR-7174: Added a separate serverless-cloudstac.yml 

### DIFF
--- a/search/package.json
+++ b/search/package.json
@@ -38,6 +38,7 @@
     "start": "IS_LOCAL=true sls offline --config serverless-offline.yml",
     "deploy": "sls deploy --config serverless.yml",
     "deploy-docs": "sls s3deploy -v  --config serverless.yml",
+    "deploy-cloudstac": "sls deploy --config serverless-cloudstac.yml",
     "remove": "sls remove --config serverless.yml",
     "lint": "eslint ./lib/** ./tests/** --fix",
     "test": "jest --env=node",

--- a/search/serverless-cloudstac.yml
+++ b/search/serverless-cloudstac.yml
@@ -1,0 +1,61 @@
+service: "cmr-${self:custom.cmrStacName}-api"
+
+provider:
+  name: aws
+  runtime: nodejs10.x
+  region: us-east-1
+  role: cmrStacRole
+  deploymentBucket: ${cf:${opt:stage}.cmrStacDeploymentBucket}
+  vpc:
+    securityGroupIds:
+      - ${cf:${opt:stage}.servicesSecurityGroupId}
+    subnetIds: !Split [ ",", "${cf:${opt:stage}.subnetIds}" ]
+custom:
+  cmrStacName: ${opt:cmr-stac-name}
+  cmrStacRelativeRootUrl: ${opt:cmr-stac-relative-root-url, '/stac'}
+  logSubscription:
+      destinationArn: ${cf:${opt:stage}.logForwardingArn}
+
+functions:
+  search-api:
+    name: cmr-${self:custom.cmrStacName}-${opt:stage}
+    handler: lib/application.handler
+    timeout: 6
+    events:
+      - alb:
+          listenerArn: ${cf:${opt:stage}.servicesLbListenerArn}
+          priority: ${opt:cmr-lb-priority, 83}
+          conditions:
+            path: ${self:custom.cmrStacRelativeRootUrl}*
+    logSubscription: true
+    environment:
+      CMR_SEARCH_HOST: ${opt:cmr-search-host, 'cmr.earthdata.nasa.gov/search'}
+      CMR_PROVIDER_HOST: ${opt:cmr-provider-host, 'cmr.earthdata.nasa.gov/ingest/providers'}
+      CMR_SEARCH_PROTOCOL: ${opt:cmr-search-protocol, 'https'}
+      CMR_STAC_RELATIVE_ROOT_URL: ${self:custom.cmrStacRelativeRootUrl}
+      BROWSE_PATH: year/month/day
+      LOG_DISABLED: false
+      LOG_LEVEL: info
+      STAC_VERSION: 1.0.0-beta.2
+
+resources:
+  Resources:
+    cmrStacRole:
+      Type: AWS::IAM::Role
+      Properties:
+        RoleName: cmrStacRole-${self:custom.cmrStacName}-${opt:stage}
+        PermissionsBoundary: arn:aws:iam::#{AWS::AccountId}:policy/NGAPShRoleBoundary
+        ManagedPolicyArns:
+          - arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole
+        AssumeRolePolicyDocument:
+          Version: "2012-10-17"
+          Statement:
+            - Effect: "Allow"
+              Principal:
+                Service:
+                  - "lambda.amazonaws.com"
+              Action:
+                - "sts:AssumeRole"
+plugins:
+  - serverless-pseudo-parameters
+  - serverless-plugin-log-subscription


### PR DESCRIPTION
When deploying both cmr-stac and cmr-cloudstac using the same serverless.yml, there is a conflict that they both try to create the same bucket, which needs to be unique. Created a new serverless-cloudstac.yml that has the same content as serverless.yml but without creating bucket and uploading the docs file. It only needs to be done in one of the deployments.