### PR TITLE
CMR-7174: Change the bucket name.

### DIFF
--- a/search/package.json
+++ b/search/package.json
@@ -36,7 +36,7 @@
   "scripts": {
     "debug": "export SLS_DEBUG=* && IS_LOCAL=true sls offline --config serverless-offline.yml",
     "start": "IS_LOCAL=true sls offline --config serverless-offline.yml",
-    "deploy": "sls deploy --config serverless.yml",
+    "deploy": "sls deploy -v --config serverless.yml",
     "deploy-docs": "sls s3deploy -v  --config serverless.yml",
     "deploy-cloudstac": "sls deploy --config serverless-cloudstac.yml",
     "remove": "sls remove --config serverless.yml",

--- a/search/serverless.yml
+++ b/search/serverless.yml
@@ -15,7 +15,7 @@ custom:
   cmrStacRelativeRootUrl: ${opt:cmr-stac-relative-root-url, '/stac'}
   logSubscription:
       destinationArn: ${cf:${opt:stage}.logForwardingArn}
-  docsBucket: cmr-stac-static-bucket-${opt:stage}
+  docsBucket: cmr-stac-docs-bucket-${opt:stage}
   assets:
     targets:
       - bucket:


### PR DESCRIPTION
We've decided not to share the bucket with cmr-stac static catalogs, which will be located in a separate bucket in us-west-2 region.  So, the bucket created in serverless.yml will only be used for stac docs file.