### PR TITLE
[CMR-7209] async s3 writes when mirroring API

### DIFF
--- a/mirror-api/requirements.txt
+++ b/mirror-api/requirements.txt
@@ -1,5 +1,7 @@
-pystac
-httpx
 asyncio
+aioboto3
+aiofiles
 boto3
+httpx
+git+git:/github.com/stac-utils/pystac@mah/async
 requests


### PR DESCRIPTION
The mirror-api.py script has been updated to use an experimental branch of PySTAC (https://github.com/stac-utils/pystac/tree/mah/async) that allows for async writing of a catalog.

Writing 23K Items + 4K sub-catalogs takes 18 minutes, less than half the time without async.