### PR TITLE
only adjust stagePath if var is present

### DIFF
--- a/search/lib/util/index.js
+++ b/search/lib/util/index.js
@@ -64,7 +64,9 @@ function generateAppUrlWithoutRelativeRoot (event, path, queryParams = null) {
   let stagePath = '';
   if (event.requestContext) {
     const resourcePath = event.requestContext.resourcePath;
-    stagePath = resourcePath.substr(0, resourcePath.lastIndexOf('{proxy*}') - 1);
+    if (resourcePath) {
+      stagePath = resourcePath.substr(0, resourcePath.lastIndexOf('{proxy*}') - 1);
+    }
   }
   const newPath = `${stagePath}${path || ''}`;
   return protocol === 'https' ? createSecureUrl(host, newPath, queryParams) : createUrl(host, newPath, queryParams);


### PR DESCRIPTION
Checks to see if resourcePath is present in context before setting.

This will work in offline and production when a domain name is assigned to the API URL, but an API Gateway deployment with a stage will still have incorrect links. Since there's currently no use case for that this seems an acceptable solution.