### PR TITLE
add root links and update tests

### DIFF
--- a/search/lib/api/provider.js
+++ b/search/lib/api/provider.js
@@ -112,6 +112,14 @@ async function getProviders (request, response) {
       href: generateAppUrl(event, `/${provider['provider-id']}`)
     };
   });
+  const links = [
+    wfs.createLink('self', generateAppUrl(event, `/`), 'NASA CMR-STAC Root Catalog'),
+    wfs.createLink('root', generateAppUrl(event, '/'), 'NASA CMR-STAC Root Catalog'),
+    wfs.createLink('about',
+      'https://wiki.earthdata.nasa.gov/display/ED/SpatioTemporal+Asset+Catalog+%2528CMR-STAC%2529+Documentation',
+      'CMR-STAC Documentation'),
+    ...providerLinks
+  ];
 
   // Based on the route, set different id, title and description for providerCatalog.
   let id;
@@ -129,7 +137,7 @@ async function getProviders (request, response) {
     stac_version: settings.stac.version,
     type: 'Catalog',
     description: `This is the landing page for CMR-${ID}. Each provider link contains a ${ID} endpoint.`,
-    links: providerLinks
+    links: links
   };
   response.status(200).json(providerCatalog);
 }

--- a/search/tests/api/provider.spec.js
+++ b/search/tests/api/provider.spec.js
@@ -30,7 +30,25 @@ const mockProviderResponse = [
   'short-name': `${providerId}Short`
 }));
 
-const expectedProviders = [
+const expectedLinks = [
+  {
+    title: 'NASA CMR-STAC Root Catalog',
+    rel: 'self',
+    type: 'application/json',
+    href: 'http://example.com/stac/'
+  },
+  {
+    title: 'NASA CMR-STAC Root Catalog',
+    rel: 'root',
+    type: 'application/json',
+    href: 'http://example.com/stac/'
+  },
+  {
+    title: 'CMR-STAC Documentation',
+    rel: 'about',
+    type: 'application/json',
+    href: 'https://wiki.earthdata.nasa.gov/display/ED/SpatioTemporal+Asset+Catalog+%2528CMR-STAC%2529+Documentation'
+  },
   {
     title: 'provAShort',
     rel: 'child',
@@ -51,7 +69,25 @@ const expectedProviders = [
   }
 ];
 
-const expectedCloudProviders = [
+const expectedCloudLinks = [
+  {
+    title: 'NASA CMR-STAC Root Catalog',
+    rel: 'self',
+    type: 'application/json',
+    href: 'http://example.com/cloudstac/'
+  },
+  {
+    title: 'NASA CMR-STAC Root Catalog',
+    rel: 'root',
+    type: 'application/json',
+    href: 'http://example.com/cloudstac/'
+  },
+  {
+    title: 'CMR-STAC Documentation',
+    rel: 'about',
+    type: 'application/json',
+    href: 'https://wiki.earthdata.nasa.gov/display/ED/SpatioTemporal+Asset+Catalog+%2528CMR-STAC%2529+Documentation'
+  },
   {
     title: 'provAShort',
     rel: 'child',
@@ -90,7 +126,7 @@ describe('getProviders', () => {
         stac_version: settings.stac.version,
         type: 'Catalog',
         id: 'stac',
-        links: expectedProviders
+        links: expectedLinks
       });
     });
   });
@@ -115,7 +151,7 @@ describe('getProviders', () => {
         stac_version: settings.stac.version,
         type: 'Catalog',
         id: 'cloudstac',
-        links: expectedCloudProviders
+        links: expectedCloudLinks
       });
     });
   });


### PR DESCRIPTION
Adds links to `self`, `root`, and `about` to the CMR-STAC root catalog.

The `about` link is the CMR-STAC wiki page https://wiki.earthdata.nasa.gov/display/ED/SpatioTemporal+Asset+Catalog+%2528CMR-STAC%2529+Documentation 