### PR TITLE
[CMR-7371] Use GranuleUR for Item IDs

### DIFF
--- a/search/lib/api/wfs.js
+++ b/search/lib/api/wfs.js
@@ -209,13 +209,13 @@ async function getItems (request, response) {
     if ((collectionsRequested && validCollections) || (!collectionsRequested)) {
       // if collections param provided, check that not all were filtered out as invalid
       if (settings.cmrStacRelativeRootUrl === '/cloudstac') {
-        // Preserve collection_concept_id and concept_id in cmrParams before deleting.
+        // Preserve collection_concept_id and granule_ur in cmrParams before deleting.
         // After checking collection_concept_ids being cloud holding collections, they
         // will be added back one by one because of POST search request requirement.
         const collectionConceptIds = cmrParams.collection_concept_id;
-        const conceptIds = cmrParams.concept_id;
+        const granuleURs = cmrParams.granule_ur;
         delete cmrParams.collection_concept_id;
-        delete cmrParams.concept_id;
+        delete cmrParams.granule_ur;
 
         // Find all the cloud holding collections applicable
         // i.e. if collection_concept_ids are present, we will get all the cloud holding collections within these ids.
@@ -227,9 +227,9 @@ async function getItems (request, response) {
             postSearchParams.append('collection_concept_id', id);
           });
         }
-        if (conceptIds) {
-          conceptIds.forEach(id => {
-            postSearchParams.append('concept_id', id);
+        if (granuleURs) {
+          granuleURs.forEach(id => {
+            postSearchParams.append('granule_ur', id);
           });
         }
         granulesResult = await cmr.findGranules(postSearchParams);
@@ -273,8 +273,8 @@ async function getItems (request, response) {
 async function getItem (request, response) {
   const providerId = request.params.providerId;
   const collectionId = request.params.collectionId;
-  const conceptId = request.params.itemId;
-  logger.info(`GET /${providerId}/collections/${collectionId}/items/${conceptId}`);
+  const itemId = request.params.itemId;
+  logger.info(`GET /${providerId}/collections/${collectionId}/items/${itemId}`);
   const event = request.apiGateway.event;
 
   // We need to make sure the granule belongs to the provider and the collection.
@@ -285,7 +285,7 @@ async function getItem (request, response) {
       .json(`Collection [${collectionId}] not found for provider [${providerId}]`);
   }
   const cmrParams = Object.assign(
-    { concept_id: conceptId },
+    { granule_ur: itemId },
     { collection_concept_id: cmrCollectionId }
   );
 

--- a/search/lib/cmr.js
+++ b/search/lib/cmr.js
@@ -21,7 +21,7 @@ const STAC_SEARCH_PARAMS_CONVERSION_MAP = {
   limit: ['page_size', _.identity],
   page: ['page_num', _.identity],
   collections: ['collection_concept_id', _.identity],
-  ids: ['concept_id', _.identity]
+  ids: ['granule_ur', _.identity]
 };
 
 const DEFAULT_HEADERS = {

--- a/search/lib/convert/granules.js
+++ b/search/lib/convert/granules.js
@@ -239,9 +239,10 @@ async function cmrGranuleToStac (event, granule) {
 
   assets.metadata = wfs.createAssetLink(makeCmrSearchUrl(`/concepts/${granule.id}.native`));
   const collectionId = await cmr.cmrCollectionIdToStacId(granule.collection_concept_id);
+  const gid = granule.umm.GranuleUR;
   return {
     type: 'Feature',
-    id: granule.id,
+    id: gid,
     stac_version: settings.stac.version,
     stac_extensions: extensions,
     collection: collectionId,
@@ -251,7 +252,7 @@ async function cmrGranuleToStac (event, granule) {
       {
         rel: 'self',
         href: generateAppUrl(event,
-          `/${granule.data_center}/collections/${collectionId}/items/${granule.id}`)
+          `/${granule.data_center}/collections/${collectionId}/items/${gid}`)
       },
       {
         rel: 'parent',

--- a/search/tests/convert/granules.spec.js
+++ b/search/tests/convert/granules.spec.js
@@ -272,7 +272,10 @@ describe('granuleToItem', () => {
         }
       ],
       data_center: 'USA',
-      points: ['77,139']
+      points: ['77,139'],
+      umm: {
+        GranuleUR: 1
+      }
     }];
 
     const event = { headers: { Host: 'example.com' }, path: '/stac', queryStringParameters: [] };

--- a/search/tests/example-data/lancemodis_cmr_gran.json
+++ b/search/tests/example-data/lancemodis_cmr_gran.json
@@ -22,5 +22,8 @@
     "type": "application/x-hdfeos",
     "hreflang": "en-US",
     "href": "https://nrt3.modaps.eosdis.nasa.gov/archive/allData/61/MYD02HKM/2020/162/MYD02HKM.A2020162.2355.061.NRT.hdf"
-  }]
+  }],
+  "umm": {
+    "GranuleUR": "G1848422111-LANCEMODIS"
+  }
 }

--- a/search/tests/example-data/lpdaac_cloud_gran.json
+++ b/search/tests/example-data/lpdaac_cloud_gran.json
@@ -1,6 +1,6 @@
 {
   "type": "Feature",
-  "id": "G1328420897-LPDAAC_ECS",
+  "id": "SC:VIP01.004:2242263776",
   "stac_version": "1.0.0",
   "stac_extensions": [],
   "collection": "VIP01.v004",
@@ -40,7 +40,7 @@
   "links": [
     {
       "rel": "self",
-      "href": "http://example.com/cloudstac/LPDAAC_ECS/collections/VIP01.v004/items/G1328420897-LPDAAC_ECS"
+      "href": "http://example.com/cloudstac/LPDAAC_ECS/collections/VIP01.v004/items/SC:VIP01.004:2242263776"
     },
     {
       "rel": "parent",

--- a/search/tests/example-data/lpdaac_stac_gran.json
+++ b/search/tests/example-data/lpdaac_stac_gran.json
@@ -1,6 +1,6 @@
 {
   "type": "Feature",
-  "id": "G1328420897-LPDAAC_ECS",
+  "id": "SC:VIP01.004:2242263776",
   "stac_version": "1.0.0",
   "stac_extensions": [],
   "collection": "VIP01.v004",
@@ -40,7 +40,7 @@
   "links": [
     {
       "rel": "self",
-      "href": "http://example.com/stac/LPDAAC_ECS/collections/VIP01.v004/items/G1328420897-LPDAAC_ECS"
+      "href": "http://example.com/stac/LPDAAC_ECS/collections/VIP01.v004/items/SC:VIP01.004:2242263776"
     },
     {
       "rel": "parent",


### PR DESCRIPTION
This changes Item IDs to use the provider `GranuleUR` in the UMM JSON metadata.

Resolves #21 