### PR TITLE
[CMR-7289] protocol 

### DIFF
--- a/search/lib/api/provider.js
+++ b/search/lib/api/provider.js
@@ -121,6 +121,8 @@ async function getProviders (request, response) {
     ...providerLinks
   ];
 
+  console.log(`PROTOCOL = ${generateAppUrl(event, '/')}`);
+
   // Based on the route, set different id, title and description for providerCatalog.
   let id;
 

--- a/search/lib/api/provider.js
+++ b/search/lib/api/provider.js
@@ -121,8 +121,6 @@ async function getProviders (request, response) {
     ...providerLinks
   ];
 
-  console.log(`PROTOCOL = ${generateAppUrl(event, '/')}`);
-
   // Based on the route, set different id, title and description for providerCatalog.
   let id;
 

--- a/search/lib/convert/collections.js
+++ b/search/lib/convert/collections.js
@@ -38,9 +38,7 @@ function cmrCollSpatialToExtents (cmrColl) {
 
 function createExtent (cmrCollection) {
   return {
-    crs: 'https://www.opengis.net/def/crs/OGC/1.3/CRS84',
     spatial: { bbox: [cmrCollSpatialToExtents(cmrCollection)] },
-    trs: 'https://www.opengis.net/def/uom/ISO-8601/0/Gregorian',
     temporal: {
       interval: [
         [

--- a/search/lib/convert/collections.js
+++ b/search/lib/convert/collections.js
@@ -38,9 +38,9 @@ function cmrCollSpatialToExtents (cmrColl) {
 
 function createExtent (cmrCollection) {
   return {
-    crs: 'http://www.opengis.net/def/crs/OGC/1.3/CRS84',
+    crs: 'https://www.opengis.net/def/crs/OGC/1.3/CRS84',
     spatial: { bbox: [cmrCollSpatialToExtents(cmrCollection)] },
-    trs: 'http://www.opengis.net/def/uom/ISO-8601/0/Gregorian',
+    trs: 'https://www.opengis.net/def/uom/ISO-8601/0/Gregorian',
     temporal: {
       interval: [
         [

--- a/search/lib/settings.js
+++ b/search/lib/settings.js
@@ -54,7 +54,8 @@ function getSettings () {
     settings.cmrStacRelativeRootUrl = process.env.CMR_STAC_RELATIVE_ROOT_URL || '/stac';
     settings.cmrSearchHost = process.env.CMR_SEARCH_HOST || 'cmr.earthdata.nasa.gov/search';
     settings.cmrProviderHost = process.env.CMR_PROVIDER_HOST || 'cmr.earthdata.nasa.gov/ingest/providers';
-    settings.cmrSearchProtocol = process.env.CMR_SEARCH_PROTOCOL || 'https';
+    settings.cmrProtocol = process.env.CMR_PROTOCOL || 'https';
+    settings.protocol = process.env.CMR_STAC_PROTOCOL || 'https';
     settings.cacheTtl = process.env.CMR_STAC_CACHE_TTL || 14400;
     settings.maxLimit = process.env.CMR_STAC_MAX_LIMIT || 500;
 

--- a/search/lib/util/index.js
+++ b/search/lib/util/index.js
@@ -23,21 +23,14 @@ function getHostHeader (event) {
   return getKeyCaseInsensitive(event.headers, 'host');
 }
 
-function getProtoHeader (event) {
-  return getKeyCaseInsensitive(event.headers, 'CloudFront-Forwarded-Proto') ||
-    getKeyCaseInsensitive(event.headers, 'X-Forwarded-Proto') || 'http';
-}
-
 function createRedirectUrl (event, redirectPath) {
   const host = getHostHeader(event);
-  const protocol = getProtoHeader(event);
-  return `${protocol}://${host}${settings.cmrStacRelativeRootUrl}${redirectPath}`;
+  return `${settings.protocol}://${host}${settings.cmrStacRelativeRootUrl}${redirectPath}`;
 }
 
 function getStacBaseUrl (event) {
   const host = getHostHeader(event);
-  const protocol = getProtoHeader(event);
-  return `${protocol}://${host}${settings.cmrStacRelativeRootUrl}${settings.stac.stacRelativePath}`;
+  return `${settings.protocol}://${host}${settings.cmrStacRelativeRootUrl}${settings.stac.stacRelativePath}`;
 }
 
 function createUrl (host, path, queryParams) {
@@ -60,7 +53,6 @@ function createSecureUrl (host, path, queryParams) {
 
 function generateAppUrlWithoutRelativeRoot (event, path, queryParams = null) {
   const host = getHostHeader(event);
-  const protocol = getProtoHeader(event);
 
   let stagePath = '';
   if (event.requestContext) {
@@ -71,7 +63,11 @@ function generateAppUrlWithoutRelativeRoot (event, path, queryParams = null) {
   }
 
   const newPath = `${stagePath}${path || ''}`;
-  return protocol === 'https' ? createSecureUrl(host, newPath, queryParams) : createUrl(host, newPath, queryParams);
+  if (settings.protocol === 'https') {
+    return createSecureUrl(host, newPath, queryParams);
+  } else {
+    return createUrl(host, newPath, queryParams);
+  }
 }
 
 function generateAppUrl (event, path, queryParams = null) {
@@ -95,7 +91,7 @@ function makeAsyncHandler (fn) {
 
 const makeCmrSearchUrl = (path, queryParams = null) => {
   return UrlBuilder.create()
-    .withProtocol(settings.cmrSearchProtocol)
+    .withProtocol(settings.cmrProtocol)
     .withHost(settings.cmrSearchHost)
     .withPath(path)
     .withQuery(queryParams)

--- a/search/package.json
+++ b/search/package.json
@@ -35,7 +35,7 @@
   },
   "scripts": {
     "debug": "export SLS_DEBUG=* && IS_LOCAL=true sls offline --config serverless.yml",
-    "start": "IS_LOCAL=true sls offline --config serverless.yml --protocol https",
+    "start": "IS_LOCAL=true sls offline --config serverless.yml --protocol http",
     "deploy": "sls deploy --config serverless.yml",
     "deploy-docs": "sls s3deploy -v  --config serverless-ngap.yml",
     "ngap-deploy": "sls deploy --config serverless-ngap.yml",

--- a/search/package.json
+++ b/search/package.json
@@ -35,7 +35,7 @@
   },
   "scripts": {
     "debug": "export SLS_DEBUG=* && IS_LOCAL=true sls offline --config serverless.yml",
-    "start": "IS_LOCAL=true sls offline --config serverless.yml",
+    "start": "IS_LOCAL=true sls offline --config serverless.yml --protocol https",
     "deploy": "sls deploy --config serverless.yml",
     "deploy-docs": "sls s3deploy -v  --config serverless-ngap.yml",
     "ngap-deploy": "sls deploy --config serverless-ngap.yml",

--- a/search/serverless.yml
+++ b/search/serverless.yml
@@ -20,6 +20,7 @@ functions:
       CMR_SEARCH_HOST: ${opt:cmr-search-host, 'cmr.earthdata.nasa.gov/search'}
       CMR_PROVIDER_HOST: ${opt:cmr-provider-host, 'cmr.earthdata.nasa.gov/ingest/providers'}
       CMR_STAC_RELATIVE_ROOT_URL: /stac
+      CMR_STAC_PROTOCOL: ${opt:protocol, 'https'}
       LOG_LEVEL: info
       LOG_DISABLED: false
       STAC_VERSION: 1.0.0

--- a/search/tests/api/provider.spec.js
+++ b/search/tests/api/provider.spec.js
@@ -35,13 +35,13 @@ const expectedLinks = [
     title: 'NASA CMR-STAC Root Catalog',
     rel: 'self',
     type: 'application/json',
-    href: 'http://example.com/stac/'
+    href: 'https://example.com/stac/'
   },
   {
     title: 'NASA CMR-STAC Root Catalog',
     rel: 'root',
     type: 'application/json',
-    href: 'http://example.com/stac/'
+    href: 'https://example.com/stac/'
   },
   {
     title: 'CMR-STAC Documentation',
@@ -53,19 +53,19 @@ const expectedLinks = [
     title: 'provAShort',
     rel: 'child',
     type: 'application/json',
-    href: 'http://example.com/stac/provA'
+    href: 'https://example.com/stac/provA'
   },
   {
     title: 'provBShort',
     rel: 'child',
     type: 'application/json',
-    href: 'http://example.com/stac/provB'
+    href: 'https://example.com/stac/provB'
   },
   {
     title: 'provCShort',
     rel: 'child',
     type: 'application/json',
-    href: 'http://example.com/stac/provC'
+    href: 'https://example.com/stac/provC'
   }
 ];
 
@@ -74,13 +74,13 @@ const expectedCloudLinks = [
     title: 'NASA CMR-STAC Root Catalog',
     rel: 'self',
     type: 'application/json',
-    href: 'http://example.com/cloudstac/'
+    href: 'https://example.com/cloudstac/'
   },
   {
     title: 'NASA CMR-STAC Root Catalog',
     rel: 'root',
     type: 'application/json',
-    href: 'http://example.com/cloudstac/'
+    href: 'https://example.com/cloudstac/'
   },
   {
     title: 'CMR-STAC Documentation',
@@ -92,19 +92,19 @@ const expectedCloudLinks = [
     title: 'provAShort',
     rel: 'child',
     type: 'application/json',
-    href: 'http://example.com/cloudstac/provA'
+    href: 'https://example.com/cloudstac/provA'
   },
   {
     title: 'provBShort',
     rel: 'child',
     type: 'application/json',
-    href: 'http://example.com/cloudstac/provB'
+    href: 'https://example.com/cloudstac/provB'
   },
   {
     title: 'provCShort',
     rel: 'child',
     type: 'application/json',
-    href: 'http://example.com/cloudstac/provC'
+    href: 'https://example.com/cloudstac/provC'
   }
 ];
 
@@ -169,39 +169,39 @@ describe('getProvider', () => {
         links: [
           {
             rel: 'self',
-            href: 'http://example.com/stac/USGS_EROS',
+            href: 'https://example.com/stac/USGS_EROS',
             title: 'Provider catalog',
             type: 'application/json'
           },
           {
             rel: 'root',
-            href: 'http://example.com/stac/',
+            href: 'https://example.com/stac/',
             title: 'Root catalog',
             type: 'application/json'
           },
           {
             rel: 'collections',
-            href: 'http://example.com/stac/USGS_EROS/collections',
+            href: 'https://example.com/stac/USGS_EROS/collections',
             title: 'Provider Collections',
             type: 'application/json'
           },
           {
             rel: 'search',
-            href: 'http://example.com/stac/USGS_EROS/search',
+            href: 'https://example.com/stac/USGS_EROS/search',
             title: 'Provider Item Search',
             type: 'application/geo+json',
             method: 'GET'
           },
           {
             rel: 'search',
-            href: 'http://example.com/stac/USGS_EROS/search',
+            href: 'https://example.com/stac/USGS_EROS/search',
             title: 'Provider Item Search',
             type: 'application/geo+json',
             method: 'POST'
           },
           {
             rel: 'conformance',
-            href: 'http://example.com/stac/USGS_EROS/conformance',
+            href: 'https://example.com/stac/USGS_EROS/conformance',
             title: 'Conformance Classes',
             type: 'application/geo+json'
           },
@@ -261,39 +261,39 @@ describe('getProvider', () => {
         links: [
           {
             rel: 'self',
-            href: 'http://example.com/cloudstac/GHRC_DAAC',
+            href: 'https://example.com/cloudstac/GHRC_DAAC',
             title: 'Provider catalog',
             type: 'application/json'
           },
           {
             rel: 'root',
-            href: 'http://example.com/cloudstac/',
+            href: 'https://example.com/cloudstac/',
             title: 'Root catalog',
             type: 'application/json'
           },
           {
             rel: 'collections',
-            href: 'http://example.com/cloudstac/GHRC_DAAC/collections',
+            href: 'https://example.com/cloudstac/GHRC_DAAC/collections',
             title: 'Provider Collections',
             type: 'application/json'
           },
           {
             rel: 'search',
-            href: 'http://example.com/cloudstac/GHRC_DAAC/search',
+            href: 'https://example.com/cloudstac/GHRC_DAAC/search',
             title: 'Provider Item Search',
             type: 'application/geo+json',
             method: 'GET'
           },
           {
             rel: 'search',
-            href: 'http://example.com/cloudstac/GHRC_DAAC/search',
+            href: 'https://example.com/cloudstac/GHRC_DAAC/search',
             title: 'Provider Item Search',
             type: 'application/geo+json',
             method: 'POST'
           },
           {
             rel: 'conformance',
-            href: 'http://example.com/cloudstac/GHRC_DAAC/conformance',
+            href: 'https://example.com/cloudstac/GHRC_DAAC/conformance',
             title: 'Conformance Classes',
             type: 'application/geo+json'
           },
@@ -332,7 +332,7 @@ describe('getProvider', () => {
         links: [
           {
             rel: 'next',
-            href: 'http://example.com?page=2'
+            href: 'https://example.com?page=2'
           }
         ],
         conformsTo: [

--- a/search/tests/api/stac.spec.js
+++ b/search/tests/api/stac.spec.js
@@ -52,15 +52,15 @@ describe('STAC Search', () => {
     links: [
       {
         rel: 'self',
-        href: 'http://example.com'
+        href: 'https://example.com'
       },
       {
         rel: 'root',
-        href: 'http://example.com/stac/'
+        href: 'https://example.com/stac/'
       },
       {
         rel: 'next',
-        href: 'http://example.com?page=2',
+        href: 'https://example.com?page=2',
         method: 'GET'
       }
     ]

--- a/search/tests/api/wfs.spec.js
+++ b/search/tests/api/wfs.spec.js
@@ -66,13 +66,13 @@ describe('wfs routes', () => {
           type: 'Catalog',
           links: [
             {
-              href: 'http://example.com/stac/LPDAAC/collections',
+              href: 'https://example.com/stac/LPDAAC/collections',
               rel: 'self',
               title: 'All collections provided by LPDAAC',
               type: 'application/json'
             },
             {
-              href: 'http://example.com/stac/',
+              href: 'https://example.com/stac/',
               rel: 'root',
               title: 'CMR-STAC Root',
               type: 'application/json'
@@ -101,13 +101,13 @@ describe('wfs routes', () => {
           description: 'All cloud holding collections provided by LPDAAC',
           links: [
             {
-              href: 'http://example.com/cloudstac/LPDAAC/collections',
+              href: 'https://example.com/cloudstac/LPDAAC/collections',
               rel: 'self',
               title: 'All cloud holding collections provided by LPDAAC',
               type: 'application/json'
             },
             {
-              href: 'http://example.com/cloudstac/',
+              href: 'https://example.com/cloudstac/',
               rel: 'root',
               title: 'CMR-CLOUDSTAC Root',
               type: 'application/json'
@@ -196,11 +196,11 @@ describe('wfs routes', () => {
           links: [
             {
               rel: 'self',
-              href: 'http://example.com'
+              href: 'https://example.com'
             },
             {
               rel: 'root',
-              href: 'http://example.com/stac/'
+              href: 'https://example.com/stac/'
             }
           ],
           features: exampleData.stacGrans
@@ -227,15 +227,15 @@ describe('wfs routes', () => {
           links: [
             {
               rel: 'self',
-              href: 'http://example.com?limit=2'
+              href: 'https://example.com?limit=2'
             },
             {
               rel: 'root',
-              href: 'http://example.com/stac/'
+              href: 'https://example.com/stac/'
             },
             {
               rel: 'next',
-              href: 'http://example.com?limit=2&page=2',
+              href: 'https://example.com?limit=2&page=2',
               method: 'GET'
             }
           ],
@@ -261,16 +261,16 @@ describe('wfs routes', () => {
           links: [
             {
               rel: 'self',
-              href: 'http://example.com?page=2'
+              href: 'https://example.com?page=2'
             },
             {
               rel: 'root',
-              href: 'http://example.com/stac/'
+              href: 'https://example.com/stac/'
             },
             {
               rel: 'prev',
               method: 'GET',
-              href: 'http://example.com?page=1'
+              href: 'https://example.com?page=1'
             }
           ],
           features: exampleData.stacGrans
@@ -301,11 +301,11 @@ describe('wfs routes', () => {
           links: [
             {
               rel: 'self',
-              href: 'http://example.com'
+              href: 'https://example.com'
             },
             {
               rel: 'root',
-              href: 'http://example.com/cloudstac/'
+              href: 'https://example.com/cloudstac/'
             }
           ],
           features: exampleData.cloudstacGrans
@@ -332,15 +332,15 @@ describe('wfs routes', () => {
           links: [
             {
               rel: 'self',
-              href: 'http://example.com?limit=2'
+              href: 'https://example.com?limit=2'
             },
             {
               rel: 'root',
-              href: 'http://example.com/cloudstac/'
+              href: 'https://example.com/cloudstac/'
             },
             {
               rel: 'next',
-              href: 'http://example.com?limit=2&page=2',
+              href: 'https://example.com?limit=2&page=2',
               method: 'GET'
             }
           ],
@@ -366,16 +366,16 @@ describe('wfs routes', () => {
           links: [
             {
               rel: 'self',
-              href: 'http://example.com?page=2'
+              href: 'https://example.com?page=2'
             },
             {
               rel: 'root',
-              href: 'http://example.com/cloudstac/'
+              href: 'https://example.com/cloudstac/'
             },
             {
               rel: 'prev',
               method: 'GET',
-              href: 'http://example.com?page=1'
+              href: 'https://example.com?page=1'
             }
           ],
           features: exampleData.cloudstacGrans

--- a/search/tests/convert/collections.spec.js
+++ b/search/tests/convert/collections.spec.js
@@ -111,7 +111,6 @@ describe('collections', () => {
       expect(cmrCollToWFSColl(event, cmrColl)).toEqual({
         description: 'summary',
         extent: {
-          crs: 'https://www.opengis.net/def/crs/OGC/1.3/CRS84',
           spatial: {
             bbox: [
               [
@@ -129,8 +128,7 @@ describe('collections', () => {
                 '1'
               ]
             ]
-          },
-          trs: 'https://www.opengis.net/def/uom/ISO-8601/0/Gregorian'
+          }
         },
         links: [
           {
@@ -177,7 +175,6 @@ describe('collections', () => {
       expect(cmrCollToWFSColl(event, cmrCollTemporal)).toEqual({
         description: 'summary',
         extent: {
-          crs: 'https://www.opengis.net/def/crs/OGC/1.3/CRS84',
           spatial: {
             bbox: [
               [
@@ -195,8 +192,7 @@ describe('collections', () => {
                 null
               ]
             ]
-          },
-          trs: 'https://www.opengis.net/def/uom/ISO-8601/0/Gregorian'
+          }
         },
         links: [
           {

--- a/search/tests/convert/collections.spec.js
+++ b/search/tests/convert/collections.spec.js
@@ -111,7 +111,7 @@ describe('collections', () => {
       expect(cmrCollToWFSColl(event, cmrColl)).toEqual({
         description: 'summary',
         extent: {
-          crs: 'http://www.opengis.net/def/crs/OGC/1.3/CRS84',
+          crs: 'https://www.opengis.net/def/crs/OGC/1.3/CRS84',
           spatial: {
             bbox: [
               [
@@ -130,26 +130,26 @@ describe('collections', () => {
               ]
             ]
           },
-          trs: 'http://www.opengis.net/def/uom/ISO-8601/0/Gregorian'
+          trs: 'https://www.opengis.net/def/uom/ISO-8601/0/Gregorian'
         },
         links: [
           {
-            href: 'http://example.com/stac/LPDAAC/collections/name.vversion',
+            href: 'https://example.com/stac/LPDAAC/collections/name.vversion',
             rel: 'self',
             title: 'Info about this collection',
             type: 'application/json'
           }, {
             rel: 'root',
-            href: 'http://example.com/stac',
+            href: 'https://example.com/stac',
             title: 'Root catalog',
             type: 'application/json'
           }, {
             rel: 'parent',
-            href: 'http://example.com/stac/LPDAAC',
+            href: 'https://example.com/stac/LPDAAC',
             title: 'Parent catalog',
             type: 'application/json'
           }, {
-            href: 'http://example.com/stac/LPDAAC/collections/name.vversion/items',
+            href: 'https://example.com/stac/LPDAAC/collections/name.vversion/items',
             rel: 'items',
             title: 'Granules in this collection',
             type: 'application/json'
@@ -177,7 +177,7 @@ describe('collections', () => {
       expect(cmrCollToWFSColl(event, cmrCollTemporal)).toEqual({
         description: 'summary',
         extent: {
-          crs: 'http://www.opengis.net/def/crs/OGC/1.3/CRS84',
+          crs: 'https://www.opengis.net/def/crs/OGC/1.3/CRS84',
           spatial: {
             bbox: [
               [
@@ -196,26 +196,26 @@ describe('collections', () => {
               ]
             ]
           },
-          trs: 'http://www.opengis.net/def/uom/ISO-8601/0/Gregorian'
+          trs: 'https://www.opengis.net/def/uom/ISO-8601/0/Gregorian'
         },
         links: [
           {
-            href: 'http://example.com/stac/LPDAAC/collections/name.vversion',
+            href: 'https://example.com/stac/LPDAAC/collections/name.vversion',
             rel: 'self',
             title: 'Info about this collection',
             type: 'application/json'
           }, {
             rel: 'root',
-            href: 'http://example.com/stac',
+            href: 'https://example.com/stac',
             title: 'Root catalog',
             type: 'application/json'
           }, {
             rel: 'parent',
-            href: 'http://example.com/stac/LPDAAC',
+            href: 'https://example.com/stac/LPDAAC',
             title: 'Parent catalog',
             type: 'application/json'
           }, {
-            href: 'http://example.com/stac/LPDAAC/collections/name.vversion/items',
+            href: 'https://example.com/stac/LPDAAC/collections/name.vversion/items',
             rel: 'items',
             title: 'Granules in this collection',
             type: 'application/json'

--- a/search/tests/convert/granules.spec.js
+++ b/search/tests/convert/granules.spec.js
@@ -306,23 +306,23 @@ describe('granuleToItem', () => {
           links: [
             {
               rel: 'self',
-              href: 'http://example.com/stac/USA/collections/landsat.v1/items/1'
+              href: 'https://example.com/stac/USA/collections/landsat.v1/items/1'
             },
             {
               rel: 'parent',
-              href: 'http://example.com/stac/USA/collections/landsat.v1'
+              href: 'https://example.com/stac/USA/collections/landsat.v1'
             },
             {
               rel: 'collection',
-              href: 'http://example.com/stac/USA/collections/landsat.v1'
+              href: 'https://example.com/stac/USA/collections/landsat.v1'
             },
             {
               rel: 'root',
-              href: 'http://example.com/stac/'
+              href: 'https://example.com/stac/'
             },
             {
               rel: 'provider',
-              href: 'http://example.com/stac/USA'
+              href: 'https://example.com/stac/USA'
             },
             {
               rel: 'via',
@@ -337,11 +337,11 @@ describe('granuleToItem', () => {
         links: [
           {
             rel: 'self',
-            href: 'http://example.com/stac'
+            href: 'https://example.com/stac'
           },
           {
             rel: 'root',
-            href: 'http://example.com/stac/'
+            href: 'https://example.com/stac/'
           }
         ]
       });

--- a/search/tests/example-data/lancemodis_cloud_gran.json
+++ b/search/tests/example-data/lancemodis_cloud_gran.json
@@ -40,23 +40,23 @@
   "links": [
     {
       "rel": "self",
-      "href": "http://example.com/cloudstac/LANCEMODIS/collections/MYD02HKM.v6.1NRT/items/G1848422111-LANCEMODIS"
+      "href": "https://example.com/cloudstac/LANCEMODIS/collections/MYD02HKM.v6.1NRT/items/G1848422111-LANCEMODIS"
     },
     {
       "rel": "parent",
-      "href": "http://example.com/cloudstac/LANCEMODIS/collections/MYD02HKM.v6.1NRT"
+      "href": "https://example.com/cloudstac/LANCEMODIS/collections/MYD02HKM.v6.1NRT"
     },
     {
       "rel": "collection",
-      "href": "http://example.com/cloudstac/LANCEMODIS/collections/MYD02HKM.v6.1NRT"
+      "href": "https://example.com/cloudstac/LANCEMODIS/collections/MYD02HKM.v6.1NRT"
     },
     {
       "rel": "root",
-      "href": "http://example.com/cloudstac/"
+      "href": "https://example.com/cloudstac/"
     },
     {
       "rel": "provider",
-      "href": "http://example.com/cloudstac/LANCEMODIS"
+      "href": "https://example.com/cloudstac/LANCEMODIS"
     },
     {
       "rel": "via",

--- a/search/tests/example-data/lancemodis_stac_gran.json
+++ b/search/tests/example-data/lancemodis_stac_gran.json
@@ -40,23 +40,23 @@
   "links": [
     {
       "rel": "self",
-      "href": "http://example.com/stac/LANCEMODIS/collections/MYD02HKM.v6.1NRT/items/G1848422111-LANCEMODIS"
+      "href": "https://example.com/stac/LANCEMODIS/collections/MYD02HKM.v6.1NRT/items/G1848422111-LANCEMODIS"
     },
     {
       "rel": "parent",
-      "href": "http://example.com/stac/LANCEMODIS/collections/MYD02HKM.v6.1NRT"
+      "href": "https://example.com/stac/LANCEMODIS/collections/MYD02HKM.v6.1NRT"
     },
     {
       "rel": "collection",
-      "href": "http://example.com/stac/LANCEMODIS/collections/MYD02HKM.v6.1NRT"
+      "href": "https://example.com/stac/LANCEMODIS/collections/MYD02HKM.v6.1NRT"
     },
     {
       "rel": "root",
-      "href": "http://example.com/stac/"
+      "href": "https://example.com/stac/"
     },
     {
       "rel": "provider",
-      "href": "http://example.com/stac/LANCEMODIS"
+      "href": "https://example.com/stac/LANCEMODIS"
     },
     {
       "rel": "via",

--- a/search/tests/example-data/larc_cloud_coll.json
+++ b/search/tests/example-data/larc_cloud_coll.json
@@ -8,25 +8,25 @@
   "links": [
     {
       "rel": "self",
-      "href": "http://example.com/cloudstac/LARC/collections/MOP02N.v7",
+      "href": "https://example.com/cloudstac/LARC/collections/MOP02N.v7",
       "title": "Info about this collection",
       "type": "application/json"
     },
     {
       "rel": "root",
-      "href": "http://example.com/cloudstac",
+      "href": "https://example.com/cloudstac",
       "title": "Root catalog",
       "type": "application/json"
     },
     {
       "rel": "parent",
-      "href": "http://example.com/cloudstac/LARC",
+      "href": "https://example.com/cloudstac/LARC",
       "title": "Parent catalog",
       "type": "application/json"
     },
     {
       "rel": "items",
-      "href": "http://example.com/cloudstac/LARC/collections/MOP02N.v7/items",
+      "href": "https://example.com/cloudstac/LARC/collections/MOP02N.v7/items",
       "title": "Granules in this collection",
       "type": "application/json"
     },
@@ -44,7 +44,7 @@
     }
   ],
   "extent": {
-    "crs": "http://www.opengis.net/def/crs/OGC/1.3/CRS84",
+    "crs": "https://www.opengis.net/def/crs/OGC/1.3/CRS84",
     "spatial": {
       "bbox": [
         [
@@ -55,7 +55,7 @@
         ]
       ]
     },
-    "trs": "http://www.opengis.net/def/uom/ISO-8601/0/Gregorian",
+    "trs": "https://www.opengis.net/def/uom/ISO-8601/0/Gregorian",
     "temporal": {
       "interval": [
         [

--- a/search/tests/example-data/larc_cloud_coll.json
+++ b/search/tests/example-data/larc_cloud_coll.json
@@ -44,7 +44,6 @@
     }
   ],
   "extent": {
-    "crs": "https://www.opengis.net/def/crs/OGC/1.3/CRS84",
     "spatial": {
       "bbox": [
         [
@@ -55,7 +54,6 @@
         ]
       ]
     },
-    "trs": "https://www.opengis.net/def/uom/ISO-8601/0/Gregorian",
     "temporal": {
       "interval": [
         [

--- a/search/tests/example-data/larc_stac_coll.json
+++ b/search/tests/example-data/larc_stac_coll.json
@@ -8,25 +8,25 @@
   "links": [
     {
       "rel": "self",
-      "href": "http://example.com/stac/LARC/collections/MOP02N.v7",
+      "href": "https://example.com/stac/LARC/collections/MOP02N.v7",
       "title": "Info about this collection",
       "type": "application/json"
     },
     {
       "rel": "root",
-      "href": "http://example.com/stac",
+      "href": "https://example.com/stac",
       "title": "Root catalog",
       "type": "application/json"
     },
     {
       "rel": "parent",
-      "href": "http://example.com/stac/LARC",
+      "href": "https://example.com/stac/LARC",
       "title": "Parent catalog",
       "type": "application/json"
     },
     {
       "rel": "items",
-      "href": "http://example.com/stac/LARC/collections/MOP02N.v7/items",
+      "href": "https://example.com/stac/LARC/collections/MOP02N.v7/items",
       "title": "Granules in this collection",
       "type": "application/json"
     },
@@ -44,7 +44,7 @@
     }
   ],
   "extent": {
-    "crs": "http://www.opengis.net/def/crs/OGC/1.3/CRS84",
+    "crs": "https://www.opengis.net/def/crs/OGC/1.3/CRS84",
     "spatial": {
       "bbox": [
         [
@@ -55,7 +55,7 @@
         ]
       ]
     },
-    "trs": "http://www.opengis.net/def/uom/ISO-8601/0/Gregorian",
+    "trs": "https://www.opengis.net/def/uom/ISO-8601/0/Gregorian",
     "temporal": {
       "interval": [
         [

--- a/search/tests/example-data/larc_stac_coll.json
+++ b/search/tests/example-data/larc_stac_coll.json
@@ -44,7 +44,6 @@
     }
   ],
   "extent": {
-    "crs": "https://www.opengis.net/def/crs/OGC/1.3/CRS84",
     "spatial": {
       "bbox": [
         [
@@ -55,7 +54,6 @@
         ]
       ]
     },
-    "trs": "https://www.opengis.net/def/uom/ISO-8601/0/Gregorian",
     "temporal": {
       "interval": [
         [

--- a/search/tests/example-data/lpdaac_cloud_coll.json
+++ b/search/tests/example-data/lpdaac_cloud_coll.json
@@ -8,25 +8,25 @@
   "links": [
     {
       "rel": "self",
-      "href": "http://example.com/cloudstac/LPDAAC_ECS/collections/AST14DEM.v003",
+      "href": "https://example.com/cloudstac/LPDAAC_ECS/collections/AST14DEM.v003",
       "title": "Info about this collection",
       "type": "application/json"
     },
     {
       "rel": "root",
-      "href": "http://example.com/cloudstac",
+      "href": "https://example.com/cloudstac",
       "title": "Root catalog",
       "type": "application/json"
     },
     {
       "rel": "parent",
-      "href": "http://example.com/cloudstac/LPDAAC_ECS",
+      "href": "https://example.com/cloudstac/LPDAAC_ECS",
       "title": "Parent catalog",
       "type": "application/json"
     },
     {
       "rel": "items",
-      "href": "http://example.com/cloudstac/LPDAAC_ECS/collections/AST14DEM.v003/items",
+      "href": "https://example.com/cloudstac/LPDAAC_ECS/collections/AST14DEM.v003/items",
       "title": "Granules in this collection",
       "type": "application/json"
     },
@@ -44,7 +44,7 @@
     }
   ],
   "extent": {
-    "crs": "http://www.opengis.net/def/crs/OGC/1.3/CRS84",
+    "crs": "https://www.opengis.net/def/crs/OGC/1.3/CRS84",
     "spatial": {
       "bbox": [
         [
@@ -55,7 +55,7 @@
         ]
       ]
     },
-    "trs": "http://www.opengis.net/def/uom/ISO-8601/0/Gregorian",
+    "trs": "https://www.opengis.net/def/uom/ISO-8601/0/Gregorian",
     "temporal": {
       "interval": [
         [

--- a/search/tests/example-data/lpdaac_cloud_coll.json
+++ b/search/tests/example-data/lpdaac_cloud_coll.json
@@ -44,7 +44,6 @@
     }
   ],
   "extent": {
-    "crs": "https://www.opengis.net/def/crs/OGC/1.3/CRS84",
     "spatial": {
       "bbox": [
         [
@@ -55,7 +54,6 @@
         ]
       ]
     },
-    "trs": "https://www.opengis.net/def/uom/ISO-8601/0/Gregorian",
     "temporal": {
       "interval": [
         [

--- a/search/tests/example-data/lpdaac_cloud_gran.json
+++ b/search/tests/example-data/lpdaac_cloud_gran.json
@@ -40,23 +40,23 @@
   "links": [
     {
       "rel": "self",
-      "href": "http://example.com/cloudstac/LPDAAC_ECS/collections/VIP01.v004/items/G1328420897-LPDAAC_ECS"
+      "href": "https://example.com/cloudstac/LPDAAC_ECS/collections/VIP01.v004/items/G1328420897-LPDAAC_ECS"
     },
     {
       "rel": "parent",
-      "href": "http://example.com/cloudstac/LPDAAC_ECS/collections/VIP01.v004"
+      "href": "https://example.com/cloudstac/LPDAAC_ECS/collections/VIP01.v004"
     },
     {
       "rel": "collection",
-      "href": "http://example.com/cloudstac/LPDAAC_ECS/collections/VIP01.v004"
+      "href": "https://example.com/cloudstac/LPDAAC_ECS/collections/VIP01.v004"
     },
     {
       "rel": "root",
-      "href": "http://example.com/cloudstac/"
+      "href": "https://example.com/cloudstac/"
     },
     {
       "rel": "provider",
-      "href": "http://example.com/cloudstac/LPDAAC_ECS"
+      "href": "https://example.com/cloudstac/LPDAAC_ECS"
     },
     {
       "rel": "via",

--- a/search/tests/example-data/lpdaac_stac_coll.json
+++ b/search/tests/example-data/lpdaac_stac_coll.json
@@ -8,25 +8,25 @@
   "links": [
     {
       "rel": "self",
-      "href": "http://example.com/stac/LPDAAC_ECS/collections/AST14DEM.v003",
+      "href": "https://example.com/stac/LPDAAC_ECS/collections/AST14DEM.v003",
       "title": "Info about this collection",
       "type": "application/json"
     },
     {
       "rel": "root",
-      "href": "http://example.com/stac",
+      "href": "https://example.com/stac",
       "title": "Root catalog",
       "type": "application/json"
     },
     {
       "rel": "parent",
-      "href": "http://example.com/stac/LPDAAC_ECS",
+      "href": "https://example.com/stac/LPDAAC_ECS",
       "title": "Parent catalog",
       "type": "application/json"
     },
     {
       "rel": "items",
-      "href": "http://example.com/stac/LPDAAC_ECS/collections/AST14DEM.v003/items",
+      "href": "https://example.com/stac/LPDAAC_ECS/collections/AST14DEM.v003/items",
       "title": "Granules in this collection",
       "type": "application/json"
     },
@@ -44,7 +44,7 @@
     }
   ],
   "extent": {
-    "crs": "http://www.opengis.net/def/crs/OGC/1.3/CRS84",
+    "crs": "https://www.opengis.net/def/crs/OGC/1.3/CRS84",
     "spatial": {
       "bbox": [
         [
@@ -55,7 +55,7 @@
         ]
       ]
     },
-    "trs": "http://www.opengis.net/def/uom/ISO-8601/0/Gregorian",
+    "trs": "https://www.opengis.net/def/uom/ISO-8601/0/Gregorian",
     "temporal": {
       "interval": [
         [

--- a/search/tests/example-data/lpdaac_stac_coll.json
+++ b/search/tests/example-data/lpdaac_stac_coll.json
@@ -44,7 +44,6 @@
     }
   ],
   "extent": {
-    "crs": "https://www.opengis.net/def/crs/OGC/1.3/CRS84",
     "spatial": {
       "bbox": [
         [
@@ -55,7 +54,6 @@
         ]
       ]
     },
-    "trs": "https://www.opengis.net/def/uom/ISO-8601/0/Gregorian",
     "temporal": {
       "interval": [
         [

--- a/search/tests/example-data/lpdaac_stac_gran.json
+++ b/search/tests/example-data/lpdaac_stac_gran.json
@@ -40,23 +40,23 @@
   "links": [
     {
       "rel": "self",
-      "href": "http://example.com/stac/LPDAAC_ECS/collections/VIP01.v004/items/G1328420897-LPDAAC_ECS"
+      "href": "https://example.com/stac/LPDAAC_ECS/collections/VIP01.v004/items/G1328420897-LPDAAC_ECS"
     },
     {
       "rel": "parent",
-      "href": "http://example.com/stac/LPDAAC_ECS/collections/VIP01.v004"
+      "href": "https://example.com/stac/LPDAAC_ECS/collections/VIP01.v004"
     },
     {
       "rel": "collection",
-      "href": "http://example.com/stac/LPDAAC_ECS/collections/VIP01.v004"
+      "href": "https://example.com/stac/LPDAAC_ECS/collections/VIP01.v004"
     },
     {
       "rel": "root",
-      "href": "http://example.com/stac/"
+      "href": "https://example.com/stac/"
     },
     {
       "rel": "provider",
-      "href": "http://example.com/stac/LPDAAC_ECS"
+      "href": "https://example.com/stac/LPDAAC_ECS"
     },
     {
       "rel": "via",

--- a/search/tests/util/app.spec.js
+++ b/search/tests/util/app.spec.js
@@ -1,6 +1,7 @@
 const { firstIfArray } = require('../../lib/util');
 const { extractParam } = require('../../lib/util');
 const { generateAppUrl } = require('../../lib/util');
+const settings = require('../../lib/settings');
 
 describe('firstIfArray', () => {
   it('should return value if not an array.', () => {
@@ -41,17 +42,17 @@ describe('generateAppUrl', () => {
   });
 
   it('should create a URL based on event input.', () => {
-    expect(generateAppUrl(event, path)).toBe('http://example.com/stac/path/to/resource');
+    expect(generateAppUrl(event, path)).toBe('https://example.com/stac/path/to/resource');
   });
 
   it('should create a URL based on event input with proper query params.', () => {
     expect(generateAppUrl(event, path, params))
-      .toBe('http://example.com/stac/path/to/resource?param=test');
+      .toBe('https://example.com/stac/path/to/resource?param=test');
   });
 
-  it('should create a secure url if event has secure protocol.', () => {
-    event.headers['X-Forwarded-Proto'] = 'https';
+  it('should create a insecure url if http protocol in settings.', () => {
+    settings.protocol = 'http';
     expect(generateAppUrl(event, path))
-      .toBe('https://example.com/stac/path/to/resource');
+      .toBe('http://example.com/stac/path/to/resource');
   });
 });


### PR DESCRIPTION
Rather than getting the protocol (http/https) from the headers, there is an environment variable added, CMR_STAC_PROTOCOL that defaults to `https`.  When running offline with `npm run start` it will use `http`.

In addition, the `trs` and `crs` fields in the Collection `extent` object has been removed in this PR (there is no ticket for this), as those are no longer part of the OGC API Features spec. Only a lat/lon CRS and Gregorian datetime are allowed.