### PR TITLE
[CMR-7370][CMR-7291] Reduce CMR calls to collections, handle invalid collections

### DIFF
--- a/scripts/validation/requirements.txt
+++ b/scripts/validation/requirements.txt
@@ -1,1 +1,1 @@
-stac-validator==2.1.0
+stac-validator==2.2.0

--- a/search/lib/api/provider.js
+++ b/search/lib/api/provider.js
@@ -59,8 +59,8 @@ async function getProvider (request, response) {
         'HTML documentation', 'text/html')
     ];
 
-    const childLinks = await Promise.map(providerHoldings, async (collection) => {
-      const collectionId = await cmr.cmrCollectionIdToStacId(collection['id']);
+    const childLinks = providerHoldings.map(collection => {
+      const collectionId = cmr.cmrCollectionToStacId(collection.short_name, collection.version_id);
       return wfs.createLink(
         'child',
         generateAppUrl(event, `/${providerId}/collections/${collectionId}`),

--- a/search/lib/cmr.js
+++ b/search/lib/cmr.js
@@ -170,15 +170,9 @@ async function stacIdToCmrCollectionId (providerId, stacId) {
  * @param {string} providerId CMR Provider ID
  * @param {string} collectionId CMR Collection ID
  */
-async function cmrCollectionIdToStacId (collectionId) {
-  let stacId = myCache.get(collectionId);
-  if (stacId) {
-    return stacId;
-  }
-  const collections = await findCollections({ concept_id: collectionId });
-  stacId = `${collections[0].short_name}.v${collections[0].version_id}`;
-  myCache.set(collectionId, stacId, settings.cacheTtl);
-  return stacId;
+function cmrCollectionToStacId (shortName, version = null) {
+  const collectionId = `${shortName}.v${version}`;
+  return collectionId;
 }
 
 function getFacetParams (year, month, day) {
@@ -329,7 +323,7 @@ module.exports = {
   findGranules,
   stacCollectionToCmrParams,
   stacIdToCmrCollectionId,
-  cmrCollectionIdToStacId,
+  cmrCollectionToStacId,
   getFacetParams,
   getGranuleTemporalFacets,
   convertParams

--- a/search/lib/cmr.js
+++ b/search/lib/cmr.js
@@ -128,7 +128,7 @@ function stacCollectionToCmrParams (providerId, collectionId) {
     provider_id: providerId
   };
   const parts = collectionId.split('.v');
-  if (parts.length == 1) {
+  if (parts.length === 1) {
     cmrParams.short_name = collectionId;
   } else {
     cmrParams.version = parts.pop();

--- a/search/lib/cmr.js
+++ b/search/lib/cmr.js
@@ -124,17 +124,16 @@ async function findGranules (params = {}) {
  * @param {string} collectionId The STAC Collection ID
  */
 function stacCollectionToCmrParams (providerId, collectionId) {
-  const parts = collectionId.split('.v');
-  if (parts.length < 2) {
-    return null;
-  }
-  const version = parts.pop();
-  const shortName = parts.join('.');
   const cmrParams = {
-    provider_id: providerId,
-    short_name: shortName,
-    version
+    provider_id: providerId
   };
+  const parts = collectionId.split('.v');
+  if (parts.length == 1) {
+    cmrParams.short_name = collectionId;
+  } else {
+    cmrParams.version = parts.pop();
+    cmrParams.short_name = parts.join('.');
+  }
   if (settings.cmrStacRelativeRootUrl === '/cloudstac') {
     cmrParams.tag_key = 'gov.nasa.earthdatacloud.s3';
   }
@@ -171,8 +170,11 @@ async function stacIdToCmrCollectionId (providerId, stacId) {
  * @param {string} collectionId CMR Collection ID
  */
 function cmrCollectionToStacId (shortName, version = null) {
-  const collectionId = `${shortName}.v${version}`;
-  return collectionId;
+  const invalidVersions = ['Not provided', 'NA'];
+  if (version && !invalidVersions.includes(version)) {
+    return `${shortName}.v${version}`;
+  }
+  return shortName;
 }
 
 function getFacetParams (year, month, day) {

--- a/search/lib/convert/collections.js
+++ b/search/lib/convert/collections.js
@@ -1,3 +1,4 @@
+const cmr = require('../cmr');
 const settings = require('../settings');
 const { wfs, generateAppUrl, makeCmrSearchUrl } = require('../util');
 const {
@@ -51,17 +52,16 @@ function createExtent (cmrCollection) {
 }
 
 function createLinks (event, cmrCollection) {
-  const collectionId = `${cmrCollection.short_name}.v${cmrCollection.version_id}`;
   const provider = cmrCollection.data_center;
 
   const links = [
-    wfs.createLink('self', generateAppUrl(event, `/${provider}/collections/${collectionId}`),
+    wfs.createLink('self', generateAppUrl(event, `/${provider}/collections/${cmrCollection.stacId}`),
       'Info about this collection'),
     wfs.createLink('root', generateAppUrl(event, ''),
       'Root catalog'),
     wfs.createLink('parent', generateAppUrl(event, `/${provider}`),
       'Parent catalog'),
-    wfs.createLink('items', generateAppUrl(event, `/${provider}/collections/${collectionId}/items`),
+    wfs.createLink('items', generateAppUrl(event, `/${provider}/collections/${cmrCollection.stacId}/items`),
       'Granules in this collection'),
     wfs.createLink('about', makeCmrSearchUrl(`/concepts/${cmrCollection.id}.html`),
       'HTML metadata for collection'),
@@ -73,8 +73,10 @@ function createLinks (event, cmrCollection) {
 
 function cmrCollToWFSColl (event, cmrCollection) {
   if (!cmrCollection) return [];
+  const stacId = cmr.cmrCollectionToStacId(cmrCollection.short_name, cmrCollection.version_id);
+  cmrCollection.stacId = stacId;
   const collection = {
-    id: `${cmrCollection.short_name}.v${cmrCollection.version_id}`,
+    id: stacId,
     stac_version: settings.stac.version,
     license: cmrCollection.license || 'not-provided',
     title: cmrCollection.dataset_id,

--- a/search/lib/convert/granules.js
+++ b/search/lib/convert/granules.js
@@ -238,7 +238,16 @@ async function cmrGranuleToStac (event, granule) {
   }
 
   assets.metadata = wfs.createAssetLink(makeCmrSearchUrl(`/concepts/${granule.id}.native`));
-  const { ShortName, Version } = granule.umm.CollectionReference;
+  let { ShortName, EntryTitle, Version } = granule.umm.CollectionReference;
+  if (EntryTitle) {
+    const collections = await cmr.findCollections({ entry_title: EntryTitle });
+    if (collections.length === 0) {
+      return null;
+    } else {
+      ShortName = collections[0].short_name;
+      Version = collections[0].version_id;
+    }
+  }
   const collectionId = cmr.cmrCollectionToStacId(ShortName, Version);
   const gid = granule.umm.GranuleUR;
   return {

--- a/search/lib/convert/granules.js
+++ b/search/lib/convert/granules.js
@@ -238,7 +238,8 @@ async function cmrGranuleToStac (event, granule) {
   }
 
   assets.metadata = wfs.createAssetLink(makeCmrSearchUrl(`/concepts/${granule.id}.native`));
-  const collectionId = await cmr.cmrCollectionIdToStacId(granule.collection_concept_id);
+  const { ShortName, Version } = granule.umm.CollectionReference;
+  const collectionId = cmr.cmrCollectionToStacId(ShortName, Version);
   const gid = granule.umm.GranuleUR;
   return {
     type: 'Feature',

--- a/search/tests/convert/granules.spec.js
+++ b/search/tests/convert/granules.spec.js
@@ -247,11 +247,11 @@ describe('granuleToItem', () => {
 
   describe('cmrGranulesToStac', () => {
     beforeEach(() => {
-      mockFunction(cmr, 'cmrCollectionIdToStacId', Promise.resolve('landsat.v1'));
+      mockFunction(cmr, 'cmrCollectionToStacId', 'landsat.v1');
     });
 
     afterEach(() => {
-      revertFunction(cmr, 'cmrCollectionIdToStacId');
+      revertFunction(cmr, 'cmrCollectionToStacId');
     });
 
     const cmrGran = [{
@@ -274,7 +274,11 @@ describe('granuleToItem', () => {
       data_center: 'USA',
       points: ['77,139'],
       umm: {
-        GranuleUR: 1
+        GranuleUR: 1,
+        CollectionReference: {
+          ShortName: 'landsat',
+          Version: '1'
+        }
       }
     }];
 

--- a/search/tests/example-data/lancemodis_cmr_gran.json
+++ b/search/tests/example-data/lancemodis_cmr_gran.json
@@ -24,6 +24,10 @@
     "href": "https://nrt3.modaps.eosdis.nasa.gov/archive/allData/61/MYD02HKM/2020/162/MYD02HKM.A2020162.2355.061.NRT.hdf"
   }],
   "umm": {
-    "GranuleUR": "G1848422111-LANCEMODIS"
+    "GranuleUR": "G1848422111-LANCEMODIS",
+    "CollectionReference": {
+      "ShortName": "MYD02HKM",
+      "Version": "6.1NRT"
+    }
   }
 }

--- a/search/tests/example-data/lpdaac_cmr_gran.json
+++ b/search/tests/example-data/lpdaac_cmr_gran.json
@@ -90,7 +90,8 @@
       }
     ],
     "CollectionReference": {
-      "EntryTitle": "Vegetation Index and Phenology (VIP) Vegetation Indices Daily Global 0.05Deg CMG V004"
+      "ShortName": "VIP01",
+      "Version": "004"
     },
     "RelatedUrls": [
       {


### PR DESCRIPTION
This PR:

- When getting granules it uses fields from the UMM JSON to determine the Collection ID rather than making an extra call to CMR. In the case where the `CollectionReference` in the granule only consists of `EntryTitle` (rather than `ShortName` and `Version`) a call is made to CMR to get the full collection record.
- CMR Collection conversion to STAC uses a standardized function to determine STAC ID
- Invalid versions (given as "Not provided" or "NA") are handled now by omitting version from the STAC ID. A STAC ID for a CMR Collection that does not have a valid version is just the collection `<short_name>` rather than `<short_name>.v<version>`