### PR TITLE
[CMR-7574] support all GeoJSON geometry types except GeometryCollection

### DIFF
--- a/search/lib/api/provider.js
+++ b/search/lib/api/provider.js
@@ -54,7 +54,7 @@ async function getProvider (request, response) {
       wfs.createLink('conformance', generateAppUrl(event, `/${providerId}/conformance`),
         'Conformance Classes', 'application/geo+json'),
       wfs.createLink('service-desc', 'https://api.stacspec.org/v1.0.0-beta.1/openapi.yaml',
-        'OpenAPI Doc', 'application/vnd.oai.openapi+json;version=3.0'),
+        'OpenAPI Doc', 'application/vnd.oai.openapi;version=3.0'),
       wfs.createLink('service-doc', 'https://api.stacspec.org/v1.0.0-beta.1/index.html',
         'HTML documentation', 'text/html')
     ];

--- a/search/lib/convert/coordinate.js
+++ b/search/lib/convert/coordinate.js
@@ -1,7 +1,51 @@
+const _ = require('lodash');
 const { parseOrdinateString } = require('./bounding-box');
 
 const DEG_TO_RAD = Math.PI / 180;
 const RAD_TO_DEG = 180 / Math.PI;
+
+// Convert a GeoJSON Polygon to coordinates used in CMR queries
+function convertPolygonToCMR (coordinates) {
+  if (coordinates.length > 1) {
+    throw new Error('Interior LinearRings are not supported');
+  }
+  return _.flattenDeep(_.first(coordinates)).join(',');
+}
+
+// Convert a GeoJSON LineString to coordinates used in CMR queries
+function convertLineStringToCMR (coordinates) {
+  return _.flattenDeep(coordinates).join(',');
+}
+
+// Convert a GeoJSON Point to coordinates used in CMR queries
+function convertPointToCMR (coordinates) {
+  return coordinates.join(',');
+}
+
+// Class for converting GeoJSON to CMR query parameters
+function convertGeometryToCMR (geometry) {
+  switch (geometry.type) {
+    case 'Polygon': return [['polygon', convertPolygonToCMR(geometry.coordinates)]];
+    case 'LineString': return [['line', convertLineStringToCMR(geometry.coordinates)]];
+    case 'Point': return [['point', convertPointToCMR(geometry.coordinates)]];
+    case 'MultiPolygon':
+      return [
+        ['polygon', geometry.coordinates.map(convertPolygonToCMR)],
+        ['options[polygon][or]', 'true']
+      ];
+    case 'MultiLineString':
+      return [
+        ['line', geometry.coordinates.map(convertLineStringToCMR)],
+        ['options[line][or]', 'true']
+      ];
+    case 'MultiPoint':
+      return [
+        ['point', geometry.coordinates.map(convertPointToCMR)],
+        ['options[point][or]', 'true']
+      ];
+    default: throw new Error(`Unsupported Geometry type ${geometry.type}`);
+  }
+}
 
 // Class for dealing with conversions between lat/lng, phi/theta, and x/y/z as well
 // as operations on the various forms.
@@ -126,5 +170,6 @@ class Coordinate {
 }
 
 module.exports = {
+  convertGeometryToCMR,
   Coordinate
 };

--- a/search/lib/convert/datetime.js
+++ b/search/lib/convert/datetime.js
@@ -1,6 +1,6 @@
 const ISO_8601_DATE_RX = new RegExp(
   '(\\d{4})-(\\d{2})-(\\d{2})T(\\d{2}):(\\d{2}):(\\d{2})[+-](\\d{2}):(\\d{2})');
-const DATE_TIME_RX = new RegExp('\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(\\.\\d{2:4})?Z');
+const DATE_TIME_RX = new RegExp('\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(\\.\\d{2,4})?Z');
 const DATE_RX = new RegExp('\\d{4}-\\d{2}-\\d{2}');
 const TIME_RX = new RegExp('\\d{2}:\\d{2}:\\d{2}([a|p]m)?', 'i');
 

--- a/search/lib/settings.js
+++ b/search/lib/settings.js
@@ -55,7 +55,7 @@ function getSettings () {
     settings.cmrUrl = process.env.CMR_URL || 'https://cmr.earthdata.nasa.gov';
     settings.protocol = process.env.CMR_STAC_PROTOCOL || 'https';
     settings.cacheTtl = process.env.CMR_STAC_CACHE_TTL || 14400;
-    settings.maxLimit = process.env.CMR_STAC_MAX_LIMIT || 500;
+    settings.maxLimit = process.env.CMR_STAC_MAX_LIMIT || 250;
 
     settings.throwCmrConvertParamErrors = process.env.THROW_CMR_CONVERT_PARAM_ERRORS === 'true';
 

--- a/search/tests/api/provider.spec.js
+++ b/search/tests/api/provider.spec.js
@@ -209,7 +209,7 @@ describe('getProvider', () => {
             rel: 'service-desc',
             href: 'https://api.stacspec.org/v1.0.0-beta.1/openapi.yaml',
             title: 'OpenAPI Doc',
-            type: 'application/vnd.oai.openapi+json;version=3.0'
+            type: 'application/vnd.oai.openapi;version=3.0'
           },
           {
             rel: 'service-doc',
@@ -301,7 +301,7 @@ describe('getProvider', () => {
             rel: 'service-desc',
             href: 'https://api.stacspec.org/v1.0.0-beta.1/openapi.yaml',
             title: 'OpenAPI Doc',
-            type: 'application/vnd.oai.openapi+json;version=3.0'
+            type: 'application/vnd.oai.openapi;version=3.0'
           },
           {
             rel: 'service-doc',

--- a/search/tests/cmr/cmr.spec.js
+++ b/search/tests/cmr/cmr.spec.js
@@ -196,14 +196,95 @@ describe('cmr', () => {
         expect(result).toEqual({ provider: 'provider', temporal: '12:34:00pm' });
       });
 
-      it('should convert intersects into polygon.', async () => {
+      it('should convert GeoJSON Polygon', async () => {
         const params = {
           intersects: {
-            coordinates: [[10, 10], [10, 0], [0, 10]]
+            type: 'Polygon',
+            coordinates: [
+              [[10, 10], [10, 0], [0, 10], [10, 10]]
+            ]
           }
         };
         const result = await convertParams('provider', params);
-        expect(result).toEqual({ provider: 'provider', polygon: '10,10' });
+        expect(result).toEqual({ provider: 'provider', polygon: '10,10,10,0,0,10,10,10' });
+      });
+
+      it('should convert GeoJSON Point', async () => {
+        const params = {
+          intersects: {
+            type: 'Point',
+            coordinates: [10, 10]
+          }
+        };
+        const result = await convertParams('provider', params);
+        expect(result).toEqual({ provider: 'provider', point: '10,10' });
+      });
+
+      it('should convert GeoJSON LineString', async () => {
+        const params = {
+          intersects: {
+            type: 'LineString',
+            coordinates: [
+              [10, 10], [10, 0], [0, 10]
+            ]
+          }
+        };
+        const result = await convertParams('provider', params);
+        expect(result).toEqual({ provider: 'provider', line: '10,10,10,0,0,10' });
+      });
+
+      it('should convert GeoJSON MultiPolygon', async () => {
+        const params = {
+          intersects: {
+            type: 'MultiPolygon',
+            coordinates: [
+              [
+                [[10, 10], [10, 0], [0, 10], [10, 10]]
+              ],
+              [
+                [[20, 20], [20, 10], [10, 20], [20, 20]]
+              ]
+            ]
+          }
+        };
+        const result = await convertParams('provider', params);
+        expect(result).toEqual({
+          provider: 'provider',
+          polygon: ['10,10,10,0,0,10,10,10', '20,20,20,10,10,20,20,20'],
+          'options[polygon][or]': 'true'
+        });
+      });
+
+      it('should convert GeoJSON MultiPoint', async () => {
+        const params = {
+          intersects: {
+            type: 'MultiPoint',
+            coordinates: [
+              [10, 10],
+              [20, 20]
+            ]
+          }
+        };
+        const result = await convertParams('provider', params);
+        expect(result).toEqual({ provider: 'provider', point: ['10,10', '20,20'], 'options[point][or]': 'true' });
+      });
+
+      it('should convert GeoJSON MultiLineString', async () => {
+        const params = {
+          intersects: {
+            type: 'MultiLineString',
+            coordinates: [
+              [[10, 10], [10, 0], [0, 10]],
+              [[20, 20], [20, 10], [10, 20]]
+            ]
+          }
+        };
+        const result = await convertParams('provider', params);
+        expect(result).toEqual({
+          provider: 'provider',
+          line: ['10,10,10,0,0,10', '20,20,20,10,10,20'],
+          'options[line][or]': 'true'
+        });
       });
 
       it('should convert limit to page_size.', async () => {

--- a/search/tests/convert/granules.spec.js
+++ b/search/tests/convert/granules.spec.js
@@ -185,11 +185,11 @@ describe('granuleToItem', () => {
     it('should return a bounding box from given polygon', () => {
       cmrCollection = {
         polygons: [[
-          '-46.728858 -130.072843 -51.176483 -163.057516 -69.364972 -164.573697 -61.968957 -112.537606 -46.728858 -130.072843'
+          '-46.72885 -130.07284 -51.17648 -163.05751 -69.36497 -164.57369 -61.96895 -112.53760 -46.72885 -130.07284'
         ]]
       };
       expect(cmrSpatialToStacBbox(cmrCollection))
-        .toEqual([-164.573697, -69.492825, -112.537606, -46.728858]);
+        .toEqual([-164.57369, -69.492822, -112.5376, -46.72885]);
     });
 
     it('should return a bounding box from given points', () => {


### PR DESCRIPTION
This PR resolves #188 
All GeoJSON geometry types are now supported, except for GeometryCollection.  GeometryCollection isn't even recommended by the GeoJSON spec itself, and thought that it was not included as a supported type in stac-api-spec.  Either way, CMR-STAC is unable to support multiple geometry types without making multiple queries to CMR or switching to use CMR's GraphQL (which we'll eventually do to support CQL2 in CMR-STAC).

Another limitation is that interior LinearRings are not supported for Polygon or MultiPolygon. This is a limitation in the `polygon` CMR parameter. It *may* be supported by using CMR's "shapefile" upload (supports GeoJSON), except that the performance was way too slow to make it viable.