### PR TITLE
CMR-9207: Updating key extraction and labeling for download assets

### DIFF
--- a/resources/swagger.json
+++ b/resources/swagger.json
@@ -1468,8 +1468,7 @@
             "thumbnail": {
               "title": "Thumbnail",
               "href": "http://cool-sat.com/catalog/collections/cs/items/CS3-20160503_132130_04/thumb.png",
-              "type": "image/png",
-              "key": "http://cool-sat.com/catalog/collections/cs/items/CS3-20160503_132130_04/thumb.png"
+              "type": "image/png"
             }
           }
         }

--- a/src/domains/__tests__/items.spec.ts
+++ b/src/domains/__tests__/items.spec.ts
@@ -57,10 +57,16 @@ describe("granuleToStac", () => {
           },
         ],
         assets: {
-          download: {
-            description: "the data",
-            href: "ftp://e4ftl01.cr.usgs.gov/MODIS_Composites/MOTA/MCD43A4.005/2009.09.14/MCD43A4.A2009257.h29v03.005.2009276045828.hd",
-            title: "Direct Download",
+          B09: {
+            description: "Browse image for Earthdata Search",
+            href: "ftp://e4ftl014.cr.usgs.gov/MODIS_Composites/MOTA/.B09.tif",
+            title: "Direct Download [0]",
+            roles: ["data"],
+          },
+          asset_key: {
+            description: "Example of bad url data",
+            href: "ftp://e4ftl015/ExampleBadUrl",
+            title: "Direct Download [1]",
             roles: ["data"],
           },
           provider_metadata: {
@@ -73,14 +79,12 @@ describe("granuleToStac", () => {
             href: "ftp://e4ftl01.cr.usgs.gov/MODIS_Composites/MOTA/MCD43A4.005/2009.09.14/MCD43A4.A2009257.h29v03.005.2009276045828.vinr.img",
             title: "Thumbnail [0]",
             description: "Browse image for Earthdata Search",
-            vinr: "ftp://e4ftl01.cr.usgs.gov/MODIS_Composites/MOTA/MCD43A4.005/2009.09.14/MCD43A4.A2009257.h29v03.005.2009276045828.vinr.img",
             roles: ["thumbnail"],
           },
           thumbnail_1: {
             href: "ftp://e4ftl012/ExampleBadUrl",
             title: "Thumbnail [1]",
             description: "Browse image for Earthdata Search",
-            key: "ftp://e4ftl012/ExampleBadUrl",
             roles: ["thumbnail"],
           },
         },
@@ -135,10 +139,16 @@ describe("granuleToStac", () => {
           },
         ],
         assets: {
-          download: {
-            description: "the data",
-            href: "ftp://e4ftl01.cr.usgs.gov/MODIS_Composites/MOTA/MCD43A4.005/2009.09.14/MCD43A4.A2009257.h29v03.005.2009276045828.hd",
-            title: "Direct Download",
+          B09: {
+            description: "Browse image for Earthdata Search",
+            href: "ftp://e4ftl014.cr.usgs.gov/MODIS_Composites/MOTA/.B09.tif",
+            title: "Direct Download [0]",
+            roles: ["data"],
+          },
+          asset_key: {
+            description: "Example of bad url data",
+            href: "ftp://e4ftl015/ExampleBadUrl",
+            title: "Direct Download [1]",
             roles: ["data"],
           },
           provider_metadata: {
@@ -151,14 +161,12 @@ describe("granuleToStac", () => {
             href: "ftp://e4ftl01.cr.usgs.gov/MODIS_Composites/MOTA/MCD43A4.005/2009.09.14/MCD43A4.A2009257.h29v03.005.2009276045828.vinr.img",
             title: "Thumbnail [0]",
             description: "Browse image for Earthdata Search",
-            vinr: "ftp://e4ftl01.cr.usgs.gov/MODIS_Composites/MOTA/MCD43A4.005/2009.09.14/MCD43A4.A2009257.h29v03.005.2009276045828.vinr.img",
             roles: ["thumbnail"],
           },
           thumbnail_1: {
             href: "ftp://e4ftl012/ExampleBadUrl",
             title: "Thumbnail [1]",
             description: "Browse image for Earthdata Search",
-            key: "ftp://e4ftl012/ExampleBadUrl",
             roles: ["thumbnail"],
           },
         },
@@ -208,10 +216,16 @@ describe("granuleToStac", () => {
           },
         ],
         assets: {
-          download: {
-            description: "the data",
-            href: "ftp://e4ftl01.cr.usgs.gov/MODIS_Composites/MOTA/MCD43A4.005/2009.09.14/MCD43A4.A2009257.h29v03.005.2009276045828.hd",
-            title: "Direct Download",
+          B09: {
+            description: "Browse image for Earthdata Search",
+            href: "ftp://e4ftl014.cr.usgs.gov/MODIS_Composites/MOTA/.B09.tif",
+            title: "Direct Download [0]",
+            roles: ["data"],
+          },
+          asset_key: {
+            description: "Example of bad url data",
+            href: "ftp://e4ftl015/ExampleBadUrl",
+            title: "Direct Download [1]",
             roles: ["data"],
           },
           provider_metadata: {
@@ -224,14 +238,12 @@ describe("granuleToStac", () => {
             href: "ftp://e4ftl01.cr.usgs.gov/MODIS_Composites/MOTA/MCD43A4.005/2009.09.14/MCD43A4.A2009257.h29v03.005.2009276045828.vinr.img",
             title: "Thumbnail [0]",
             description: "Browse image for Earthdata Search",
-            vinr: "ftp://e4ftl01.cr.usgs.gov/MODIS_Composites/MOTA/MCD43A4.005/2009.09.14/MCD43A4.A2009257.h29v03.005.2009276045828.vinr.img",
             roles: ["thumbnail"],
           },
           thumbnail_1: {
             href: "ftp://e4ftl012/ExampleBadUrl",
             title: "Thumbnail [1]",
             description: "Browse image for Earthdata Search",
-            key: "ftp://e4ftl012/ExampleBadUrl",
             roles: ["thumbnail"],
           },
         },

--- a/src/domains/stac.ts
+++ b/src/domains/stac.ts
@@ -42,7 +42,7 @@ const downloadAssets = (concept: Collection | Granule) => {
   return (concept.relatedUrls ?? [])
     .filter((relatedUrl) => relatedUrl["type"] === RelatedUrlType.GET_DATA)
     .reduce((downloadAssets, relatedUrl, idx, available) => {
-      const display = available.length > 1 ? ` [${idx}]` : "";
+      const display = available.length > 1 ? `[${idx}]` : "";
       const relatedUrlKey = extractAssetMapKey(relatedUrl.url);
       const downloadAsset: AssetLinks = {};
       downloadAsset[`${relatedUrlKey}`] = {

--- a/src/domains/stac.ts
+++ b/src/domains/stac.ts
@@ -42,7 +42,7 @@ const downloadAssets = (concept: Collection | Granule) => {
   return (concept.relatedUrls ?? [])
     .filter((relatedUrl) => relatedUrl["type"] === RelatedUrlType.GET_DATA)
     .reduce((downloadAssets, relatedUrl, idx, available) => {
-      const display = available.length > 1 ? `[${idx}]` : "";
+      const display = available.length > 1 ? ` [${idx}]` : "";
       const relatedUrlKey = extractAssetMapKey(relatedUrl.url);
       const downloadAsset: AssetLinks = {};
       downloadAsset[`${relatedUrlKey}`] = {

--- a/src/domains/stac.ts
+++ b/src/domains/stac.ts
@@ -42,10 +42,10 @@ const downloadAssets = (concept: Collection | Granule) => {
   return (concept.relatedUrls ?? [])
     .filter((relatedUrl) => relatedUrl["type"] === RelatedUrlType.GET_DATA)
     .reduce((downloadAssets, relatedUrl, idx, available) => {
-      const [entry, display] = available.length > 1 ? [`_${idx}`, ` [${idx}]`] : ["", ""];
-
+      const display = available.length > 1 ? ` [${idx}]` : "";
+      const relatedUrlKey = extractAssetMapKey(relatedUrl.url);
       const downloadAsset: AssetLinks = {};
-      downloadAsset[`download${entry}`] = {
+      downloadAsset[`${relatedUrlKey}`] = {
         href: relatedUrl.url,
         title: `Direct Download${display}`,
         description: relatedUrl.description,
@@ -86,13 +86,11 @@ const thumbnailAssets = (concept: Collection | Granule) => {
     )
     .reduce((metadataAssets, relatedUrl, idx, available) => {
       const [entry, display] = available.length > 1 ? [`_${idx}`, ` [${idx}]`] : ["", ""];
-      const relatedUrlKey = extractAssetMapKey(relatedUrl.url);
       const thumbnailAsset: AssetLinks = {};
       thumbnailAsset[`thumbnail${entry}`] = {
         href: relatedUrl.url,
         title: `Thumbnail${display}`,
         description: relatedUrl.description,
-        [relatedUrlKey]: relatedUrl.url,
         roles: ["thumbnail"],
       };
       return { ...metadataAssets, ...thumbnailAsset };

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -49,7 +49,7 @@ export const wrapErrorHandler = (fn: (rq: Request, rs: Response) => Promise<void
  */
 export const extractAssetMapKey = (relatedUrl: string) => {
   const urlArray = relatedUrl.split(".");
-  return urlArray[urlArray.length - 2] ? urlArray[urlArray.length - 2] : "key";
+  return urlArray[urlArray.length - 2] ? urlArray[urlArray.length - 2] : "asset_key";
 };
 
 export const stacContext = (req: Request) => {

--- a/src/utils/testUtils.ts
+++ b/src/utils/testUtils.ts
@@ -108,8 +108,14 @@ const baseGranule: Granule = {
   relatedUrls: [
     {
       urlContentType: UrlContentType.DISTRIBUTION_URL,
-      url: "ftp://e4ftl01.cr.usgs.gov/MODIS_Composites/MOTA/MCD43A4.005/2009.09.14/MCD43A4.A2009257.h29v03.005.2009276045828.hd",
-      description: "the data",
+      url: "ftp://e4ftl014.cr.usgs.gov/MODIS_Composites/MOTA/.B09.tif",
+      description: "Browse image for Earthdata Search",
+      type: RelatedUrlType.GET_DATA,
+    },
+    {
+      urlContentType: UrlContentType.DISTRIBUTION_URL,
+      url: "ftp://e4ftl015/ExampleBadUrl",
+      description: "Example of bad url data",
       type: RelatedUrlType.GET_DATA,
     },
     {


### PR DESCRIPTION
This change will adopt the current labeling strategy for download assets, by extracting the key name from the second-to-last index of the href url when split on periods.

Current functionality:
```"assets": {
      "download_0": {
            "href": "s3://lp-prod-protected/HLSL30.020/HLS.L30.T59WPT.2013101T001445.v2.0/HLS.L30.T59WPT.2013101T001445.v2.0.B09.tif",
            "title": "Direct Download [1]",
            "description": "This link provides direct download access via S3 to the granule",
            "roles": [
                  "data"
            ]
      },
      "download_1": {
            "href": "s3://lp-prod-protected/HLSL30.020/HLS.L30.T59WPT.2013101T001445.v2.0/HLS.L30.T59WPT.2013101T001445.v2.0.Fmask.tif",
            "title": "Direct Download [1]",
            "description": "This link provides direct download access via S3 to the granule",
            "roles": [
                  "data"
            ]
      },      
}
```

New functionality:
```"assets": {
      "B09": {
            "href": "s3://lp-prod-protected/HLSL30.020/HLS.L30.T59WPT.2013101T001445.v2.0/HLS.L30.T59WPT.2013101T001445.v2.0.B09.tif",
            "title": "Direct Download [1]",
            "description": "This link provides direct download access via S3 to the granule",
            "roles": [
                  "data"
            ]
      },
      "Fmask": {
            "href": "s3://lp-prod-protected/HLSL30.020/HLS.L30.T59WPT.2013101T001445.v2.0/HLS.L30.T59WPT.2013101T001445.v2.0.Fmask.tif",
            "title": "Direct Download [1]",
            "description": "This link provides direct download access via S3 to the granule",
            "roles": [
                  "data"
            ]
      },           
}
```

Here is what it will look like if the download asset has a bad URL:

```
asset_key: {
    description: "Example of bad url data",
    href: "ftp://e4ftl015/ExampleBadUrl",
    title: "Direct Download [1]",
    roles: ["data"],
},
```