### PR TITLE
CMR-10038, CMR-10039, and CMR-10040

### DIFF
--- a/src/__tests__/providerCatalog.spec.ts
+++ b/src/__tests__/providerCatalog.spec.ts
@@ -70,8 +70,8 @@ describe("GET /:provider", () => {
     it("has a collections link", async () => {
       const { body: catalog } = await request(stacApp).get("/stac/TEST");
 
-      const link: Link = catalog.links.find((l: Link) => l.rel === "data");
-      expect(link).to.have.property("rel", "data");
+      const link: Link = catalog.links.find((l: Link) => l.rel === "collections");
+      expect(link).to.have.property("rel", "collections");
       expect(link).to.have.property("type", "application/json");
       expect(link.href).to.match(/^https?:\/\/.*\/TEST\/collections$/);
       expect(link).to.have.property("title", "Provider Collections");

--- a/src/routes/browse.ts
+++ b/src/routes/browse.ts
@@ -5,7 +5,7 @@ import { Links } from "../@types/StacCatalog";
 import { getCollections } from "../domains/collections";
 import { buildQuery, stringifyQuery } from "../domains/stac";
 import { ItemNotFound } from "../models/errors";
-import { buildRootUrl, mergeMaybe, stacContext } from "../utils";
+import { mergeMaybe, stacContext } from "../utils";
 
 const collectionLinks = (req: Request, nextCursor?: string | null): Links => {
   const { stacRoot, self, path } = stacContext(req);
@@ -38,7 +38,6 @@ const collectionLinks = (req: Request, nextCursor?: string | null): Links => {
     },
   ];
 
-  const root = buildRootUrl(req);
   const originalQuery = mergeMaybe(req.query, req.body);
 
   if (nextCursor) {
@@ -46,7 +45,7 @@ const collectionLinks = (req: Request, nextCursor?: string | null): Links => {
 
     links.push({
       rel: "next",
-      href: `${root}${req.path}?${stringifyQuery(nextResultsQuery)}`,
+      href: `${stacRoot}${req.path}?${stringifyQuery(nextResultsQuery)}`,
       type: "application/geo+json",
     });
   }
@@ -80,6 +79,7 @@ export const collectionsHandler = async (req: Request, res: Response): Promise<v
   const links = collectionLinks(req, cursor);
 
   const collectionsResponse = {
+    description: `All collections provided by ${self.split("/").at(-2)}`,
     links,
     collections,
   };

--- a/src/routes/catalog.ts
+++ b/src/routes/catalog.ts
@@ -26,7 +26,7 @@ const generateSelfLinks = (req: Request): Links => {
       title: `Root Catalog`,
     },
     {
-      rel: "data",
+      rel: "collections",
       href: `${path}/collections`,
       type: "application/json",
       title: "Provider Collections",


### PR DESCRIPTION
Use collections instead of data, add a description key, and add missing /stac/ to next page link