### PR TITLE
CMR-10153: Add Keywords and Summary fields to collection search

### DIFF
--- a/src/@types/StacCollection.d.ts
+++ b/src/@types/StacCollection.d.ts
@@ -267,7 +267,8 @@ export type Link = {
   [k: string]: unknown;
 };
 export type Summaries = {
-  [k: string]: JSONSchema | Range | SetOfValues;
+  platform: string[];
+  instruments: string[];
 };
 export type CoreSchemaMetaSchema1 = {
   $id?: string;

--- a/src/domains/__tests__/collections.spec.ts
+++ b/src/domains/__tests__/collections.spec.ts
@@ -128,4 +128,29 @@ describe("collectionsToStac", () => {
       expect(collectionToStac(base)).to.have.deep.property("assets", {});
     });
   });
+
+  describe("given a valid collection result", () => {
+    it("should return all fields correctly", () => {
+      const [mockCollection] = generateCollections(1);
+
+      const stacCollection = collectionToStac(mockCollection);
+
+      // Check if all expected fields are present and correctly populated
+      expect(stacCollection).to.have.property("type", "Collection");
+      expect(stacCollection).to.have.property("id");
+      expect(stacCollection).to.have.property("title", mockCollection.title);
+      expect(stacCollection).to.have.property("description", mockCollection.description);
+      expect(stacCollection).to.have.property("stac_version");
+      expect(stacCollection).to.have.property("license");
+      expect(stacCollection).to.have.property("extent");
+      expect(stacCollection.extent).to.have.property("spatial");
+      expect(stacCollection.extent).to.have.property("temporal");
+      expect(stacCollection).to.have.property("assets");
+      expect(stacCollection).to.have.property("links");
+      expect(stacCollection).to.have.property("keywords");
+      expect(stacCollection).to.have.property("summaries");
+      expect(stacCollection.summaries).to.have.property("platform");
+      expect(stacCollection.summaries).to.have.property("instruments");
+    });
+  });
 });

--- a/src/domains/__tests__/collections.spec.ts
+++ b/src/domains/__tests__/collections.spec.ts
@@ -129,28 +129,53 @@ describe("collectionsToStac", () => {
     });
   });
 
-  describe("given a valid collection result", () => {
-    it("should return all fields correctly", () => {
+  describe("when given a valid collection", () => {
+    it("should return a STAC collection with all fields correctly populated", () => {
       const [mockCollection] = generateCollections(1);
 
       const stacCollection = collectionToStac(mockCollection);
 
       // Check if all expected fields are present and correctly populated
       expect(stacCollection).to.have.property("type", "Collection");
-      expect(stacCollection).to.have.property("id");
+      expect(stacCollection).to.have.property(
+        "id",
+        `${mockCollection.shortName}_${mockCollection.version}`
+      );
       expect(stacCollection).to.have.property("title", mockCollection.title);
       expect(stacCollection).to.have.property("description", mockCollection.description);
-      expect(stacCollection).to.have.property("stac_version");
-      expect(stacCollection).to.have.property("license");
+      expect(stacCollection).to.have.property("stac_version", "1.0.0");
+      expect(stacCollection).to.have.property("license", "proprietary");
+
       expect(stacCollection).to.have.property("extent");
+
       expect(stacCollection.extent).to.have.property("spatial");
+      expect(stacCollection.extent.spatial).to.deep.equal({ bbox: [[-180, -90, 180, 90]] });
+
       expect(stacCollection.extent).to.have.property("temporal");
+      expect(stacCollection.extent.temporal).to.deep.equal({
+        interval: [[mockCollection.timeStart, mockCollection.timeEnd]],
+      });
+
       expect(stacCollection).to.have.property("assets");
       expect(stacCollection).to.have.property("links");
+
       expect(stacCollection).to.have.property("keywords");
+      expect(stacCollection.keywords).to.deep.equal([
+        "EARTH SCIENCE",
+        "LAND SURFACE",
+        "TOPOGRAPHY",
+        "TERRAIN ELEVATION",
+      ]);
+
       expect(stacCollection).to.have.property("summaries");
       expect(stacCollection.summaries).to.have.property("platform");
+      expect(stacCollection.summaries?.platform).to.deep.equal([
+        mockCollection.platforms[0].shortName,
+      ]);
       expect(stacCollection.summaries).to.have.property("instruments");
+      expect(stacCollection.summaries?.instruments).to.deep.equal([
+        mockCollection.platforms[0].instruments[0].shortName,
+      ]);
     });
   });
 });

--- a/src/domains/collections.ts
+++ b/src/domains/collections.ts
@@ -133,43 +133,37 @@ const generateCollectionLinks = (collection: Collection, links: Links) => {
 
 const createKeywords = (collection: Collection): Keywords => {
   const { scienceKeywords } = collection;
-  const keywordsArr: string[] = [];
 
-  // Iterate though each scienceKeywords and add the
-  // value to keywordArr if it's not already present
-  scienceKeywords.forEach((keywords) => {
-    Object.values(keywords).forEach((value) => {
-      if (!keywordsArr.includes(value)) {
-        keywordsArr.push(value);
-      }
-    });
-  });
-
-  return keywordsArr;
+  return scienceKeywords.reduce((keywordsArr: string[], scienceKeyword) => {
+    return [
+      ...keywordsArr,
+      ...Object.values(scienceKeyword).filter((keyword) => !keywordsArr.includes(keyword)),
+    ];
+  }, []);
 };
 
 const createSummaries = (collection: Collection): Summaries => {
   const { platforms } = collection;
+  interface Summaries {
+    platform: string[];
+    instruments: string[];
+  }
 
-  const platformArr: string[] = [];
-  const instrumentArr: string[] = [];
+  return platforms.reduce<Summaries>(
+    (summaries, platform) => {
+      const { platform: currPlatforms, instruments: currInstruments } = summaries;
+      const { instruments, shortName } = platform;
 
-  // Extract platform and instrument shortNames from the platforms array
-  platforms.forEach((platform) => {
-    const { shortName, instruments } = platform;
-
-    platformArr.push(shortName);
-
-    instruments.forEach((instrument) => {
-      const { shortName } = instrument;
-      instrumentArr.push(shortName);
-    });
-  });
-
-  return {
-    platform: platformArr,
-    instruments: instrumentArr,
-  };
+      return {
+        platform: [...currPlatforms, shortName],
+        instruments: [
+          ...currInstruments,
+          ...instruments.map(({ shortName: instrumentShortName }) => instrumentShortName),
+        ],
+      };
+    },
+    { platform: [], instruments: [] }
+  );
 };
 
 const generateProviders = (collection: Collection) => [

--- a/src/models/GraphQLModels.ts
+++ b/src/models/GraphQLModels.ts
@@ -131,6 +131,18 @@ export type RelatedUrls = {
   };
 }[];
 
+export type Instrument = {
+  shortName: string;
+  longName: string;
+};
+
+export type Platform = {
+  type: string;
+  shortName: string;
+  longName: string;
+  instruments: Instrument[];
+};
+
 export type DirectDistributionInformation = {
   region: string;
   s3BucketAndObjectPrefixNames: string[];
@@ -159,6 +171,9 @@ export type Collection = CollectionBase & {
   useConstraints: UseConstraints | null;
   relatedUrls: RelatedUrls | null;
   directDistributionInformation: DirectDistributionInformation | null;
+
+  scienceKeywords: string[];
+  platforms: Platform[];
 };
 
 export type GranuleBase = {

--- a/src/models/GraphQLModels.ts
+++ b/src/models/GraphQLModels.ts
@@ -143,6 +143,16 @@ export type Platform = {
   instruments: Instrument[];
 };
 
+export type ScienceKeywords = {
+  category: string;
+  topic: string;
+  term: string;
+  variableLevel1?: string;
+  variableLevel2?: string;
+  variableLevel3?: string;
+  detailedVariable?: string;
+};
+
 export type DirectDistributionInformation = {
   region: string;
   s3BucketAndObjectPrefixNames: string[];
@@ -172,7 +182,7 @@ export type Collection = CollectionBase & {
   relatedUrls: RelatedUrls | null;
   directDistributionInformation: DirectDistributionInformation | null;
 
-  scienceKeywords: string[];
+  scienceKeywords: ScienceKeywords[];
   platforms: Platform[];
 };
 

--- a/src/utils/testUtils.ts
+++ b/src/utils/testUtils.ts
@@ -195,6 +195,20 @@ export const generateCollections = (
         useConstraints: null,
         directDistributionInformation: null,
         relatedUrls: [],
+        platforms: [
+          {
+            type: faker.random.words(),
+            shortName: faker.random.words(4),
+            longName: faker.random.words(4),
+            instruments: [
+              {
+                shortName: faker.random.words(4),
+                longName: faker.random.words(4),
+              },
+            ],
+          },
+        ],
+        scienceKeywords: Array.from({ length: 4 }, () => faker.lorem.word()),
       } as Collection;
     });
 };

--- a/src/utils/testUtils.ts
+++ b/src/utils/testUtils.ts
@@ -208,7 +208,14 @@ export const generateCollections = (
             ],
           },
         ],
-        scienceKeywords: Array.from({ length: 4 }, () => faker.lorem.word()),
+        scienceKeywords: [
+          {
+            category: "EARTH SCIENCE",
+            topic: "LAND SURFACE",
+            term: "TOPOGRAPHY",
+            variableLevel1: "TERRAIN ELEVATION",
+          },
+        ],
       } as Collection;
     });
 };


### PR DESCRIPTION
Implements list of associated keywords to the STAC collection output: 
![image](https://github.com/user-attachments/assets/f58fc020-685e-471c-9810-04073465503d)


Adds a 'summaries' field to the STAC collection output. This was "Strongly recommended" field in the STAC specification. According to the documentation, this should provide a quick insight into the data sources for each collection. The summaries field includes 
    - 'platform': List of platforms associated with the collection
    - 'instruments': List of instruments used in the collection
![image](https://github.com/user-attachments/assets/9656a63f-248e-4829-ab14-e71ced765ec0)
