### PR TITLE
CMR-10128: Adding metadata xml file back to assets

### DIFF
--- a/src/domains/__tests__/collections.spec.ts
+++ b/src/domains/__tests__/collections.spec.ts
@@ -66,6 +66,12 @@ describe("collectionsToStac", () => {
             roles: ["metadata"],
             title: "S3 credentials API endpoint documentation",
           },
+          metadata: {
+            href: "undefined/search/concepts/C00000000-TEST_PROV.xml",
+            roles: ["metadata"],
+            title: "CMR XML metadata for C00000000-TEST_PROV",
+            type: "application/xml"
+          },
         });
       });
     });
@@ -107,25 +113,45 @@ describe("collectionsToStac", () => {
             roles: ["metadata"],
             title: "S3 credentials API endpoint documentation",
           },
+          metadata: {
+            href: "undefined/search/concepts/C00000000-TEST_PROV.xml",
+            roles: ["metadata"],
+            title: "CMR XML metadata for C00000000-TEST_PROV",
+            type: "application/xml"
+          },
         });
       });
     });
   });
 
   describe("given a collection without direct distribution information", () => {
-    it("should return a STAC collection with empty assets", () => {
+    it("should return a STAC collection with only the xml metadata asset", () => {
       const [base] = generateCollections(1);
       const malformed: any = { ...base, directDistributionInformation: {} };
 
-      expect(collectionToStac(malformed as any)).to.have.deep.property("assets", {});
+      expect(collectionToStac(malformed as any)).to.have.deep.property("assets", {
+        metadata: {
+          href: "undefined/search/concepts/C00000000-TEST_PROV.xml",
+          roles: ["metadata"],
+          title: "CMR XML metadata for C00000000-TEST_PROV",
+          type: "application/xml"
+        }
+      });
     });
   });
 
   describe("given a collection with null direct distribution information", () => {
-    it("should return a STAC collection with empty assets", () => {
+    it("should return a STAC collection with only the xml metadata asset", () => {
       const [base] = generateCollections(1);
       base.directDistributionInformation = null;
-      expect(collectionToStac(base)).to.have.deep.property("assets", {});
+      expect(collectionToStac(base)).to.have.deep.property("assets", {
+        metadata: {
+          href: "undefined/search/concepts/C00000000-TEST_PROV.xml",
+          roles: ["metadata"],
+          title: "CMR XML metadata for C00000000-TEST_PROV",
+          type: "application/xml"
+        }
+      });
     });
   });
 

--- a/src/domains/__tests__/collections.spec.ts
+++ b/src/domains/__tests__/collections.spec.ts
@@ -70,7 +70,7 @@ describe("collectionsToStac", () => {
             href: "undefined/search/concepts/C00000000-TEST_PROV.xml",
             roles: ["metadata"],
             title: "CMR XML metadata for C00000000-TEST_PROV",
-            type: "application/xml"
+            type: "application/xml",
           },
         });
       });
@@ -117,7 +117,7 @@ describe("collectionsToStac", () => {
             href: "undefined/search/concepts/C00000000-TEST_PROV.xml",
             roles: ["metadata"],
             title: "CMR XML metadata for C00000000-TEST_PROV",
-            type: "application/xml"
+            type: "application/xml",
           },
         });
       });
@@ -134,8 +134,8 @@ describe("collectionsToStac", () => {
           href: "undefined/search/concepts/C00000000-TEST_PROV.xml",
           roles: ["metadata"],
           title: "CMR XML metadata for C00000000-TEST_PROV",
-          type: "application/xml"
-        }
+          type: "application/xml",
+        },
       });
     });
   });
@@ -149,8 +149,8 @@ describe("collectionsToStac", () => {
           href: "undefined/search/concepts/C00000000-TEST_PROV.xml",
           roles: ["metadata"],
           title: "CMR XML metadata for C00000000-TEST_PROV",
-          type: "application/xml"
-        }
+          type: "application/xml",
+        },
       });
     });
   });

--- a/src/domains/__tests__/items.spec.ts
+++ b/src/domains/__tests__/items.spec.ts
@@ -91,7 +91,7 @@ describe("granuleToStac", () => {
             href: "undefined/search/concepts/G000000000-TEST_PROV.xml",
             roles: ["metadata"],
             title: "CMR XML metadata for G000000000-TEST_PROV",
-            type: "application/xml"
+            type: "application/xml",
           },
         },
       });
@@ -179,7 +179,7 @@ describe("granuleToStac", () => {
             href: "undefined/search/concepts/G000000000-TEST_PROV.xml",
             roles: ["metadata"],
             title: "CMR XML metadata for G000000000-TEST_PROV",
-            type: "application/xml"
+            type: "application/xml",
           },
         },
       });
@@ -262,7 +262,7 @@ describe("granuleToStac", () => {
             href: "undefined/search/concepts/G000000000-TEST_PROV.xml",
             roles: ["metadata"],
             title: "CMR XML metadata for G000000000-TEST_PROV",
-            type: "application/xml"
+            type: "application/xml",
           },
         },
       });

--- a/src/domains/__tests__/items.spec.ts
+++ b/src/domains/__tests__/items.spec.ts
@@ -87,6 +87,12 @@ describe("granuleToStac", () => {
             description: "Browse image for Earthdata Search",
             roles: ["thumbnail"],
           },
+          metadata: {
+            href: "undefined/search/concepts/G000000000-TEST_PROV.xml",
+            roles: ["metadata"],
+            title: "CMR XML metadata for G000000000-TEST_PROV",
+            type: "application/xml"
+          },
         },
       });
     });
@@ -169,6 +175,12 @@ describe("granuleToStac", () => {
             description: "Browse image for Earthdata Search",
             roles: ["thumbnail"],
           },
+          metadata: {
+            href: "undefined/search/concepts/G000000000-TEST_PROV.xml",
+            roles: ["metadata"],
+            title: "CMR XML metadata for G000000000-TEST_PROV",
+            type: "application/xml"
+          },
         },
       });
     });
@@ -245,6 +257,12 @@ describe("granuleToStac", () => {
             title: "Thumbnail [1]",
             description: "Browse image for Earthdata Search",
             roles: ["thumbnail"],
+          },
+          metadata: {
+            href: "undefined/search/concepts/G000000000-TEST_PROV.xml",
+            roles: ["metadata"],
+            title: "CMR XML metadata for G000000000-TEST_PROV",
+            type: "application/xml"
           },
         },
       });

--- a/src/domains/stac.ts
+++ b/src/domains/stac.ts
@@ -183,7 +183,14 @@ const s3Assets = (concept: Collection | Granule) => {
   return s3Assets;
 };
 
-const defaultExtractors = [browseAssets, thumbnailAssets, downloadAssets, metadataAssets, s3Assets, xmlMetadataAssets];
+const defaultExtractors = [
+  browseAssets,
+  thumbnailAssets,
+  downloadAssets,
+  metadataAssets,
+  s3Assets,
+  xmlMetadataAssets,
+];
 
 /**
  * Given a concept and a list of asset extractors return available assets.

--- a/src/domains/stac.ts
+++ b/src/domains/stac.ts
@@ -35,6 +35,8 @@ import { dateTimeToRange } from "../utils/datetime";
 import { AssetLinks } from "../@types/StacCollection";
 import { Collection, Granule, RelatedUrlType } from "../models/GraphQLModels";
 
+const CMR_ROOT = process.env.CMR_URL;
+
 /**
  * Return download assets if present.
  */
@@ -73,6 +75,20 @@ const metadataAssets = (concept: Collection | Granule) => {
       };
       return { ...metadataAssets, ...metadataAsset };
     }, {} as AssetLinks);
+};
+
+/**
+ * Return the xml metadata asset.
+ */
+const xmlMetadataAssets = (concept: Collection | Granule) => {
+  const xmlMetadataAsset: AssetLinks = {};
+  xmlMetadataAsset[`metadata`] = {
+    href: `${CMR_ROOT}/search/concepts/${concept.conceptId}.xml`,
+    title: `CMR XML metadata for ${concept.conceptId}`,
+    type: "application/xml",
+    roles: ["metadata"],
+  };
+  return { ...metadataAssets, ...xmlMetadataAsset } as AssetLinks;
 };
 
 /**
@@ -167,7 +183,7 @@ const s3Assets = (concept: Collection | Granule) => {
   return s3Assets;
 };
 
-const defaultExtractors = [browseAssets, thumbnailAssets, downloadAssets, metadataAssets, s3Assets];
+const defaultExtractors = [browseAssets, thumbnailAssets, downloadAssets, metadataAssets, s3Assets, xmlMetadataAssets];
 
 /**
  * Given a concept and a list of asset extractors return available assets.


### PR DESCRIPTION
CMR-STAC users were complaining that the metadata xml file is missing from the assets field in CMR-STAC. Adding this back for them.