### PR TITLE
CMR-10184: Add link to collection if a STAC API is present in the related urls of collection metadata.

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -29,6 +29,12 @@ Then install dependencies with npm:
 npm install
 ```
 
+To run the unit test suite associated with CMR-STAC:
+
+```bash
+npm test
+```
+
 To run the CMR-STAC server locally:
 
 ```bash

--- a/docs/README.md
+++ b/docs/README.md
@@ -35,6 +35,12 @@ To run the unit test suite associated with CMR-STAC:
 npm test
 ```
 
+To lint your developed code:
+
+```bash
+npm run prettier:fix
+```
+
 To run the CMR-STAC server locally:
 
 ```bash

--- a/src/__tests__/providerCollection.spec.ts
+++ b/src/__tests__/providerCollection.spec.ts
@@ -121,7 +121,7 @@ describe("GET /:provider/collections", () => {
 
       expect(statusCode).to.equal(200);
       expect(body.collections).to.have.lengthOf(2);
-      console.log(body.collections);
+
       // Get the links of rel=item for the first collection
       const link0: Link = body.collections[0].links.find((l: Link) => l.rel === "items");
       expect(link0.href).to.equal('https://brazildatacube.dpi.inpe.br/stac/collections/MOSAIC-S2-YANOMAMI-6M-1');

--- a/src/__tests__/providerCollection.spec.ts
+++ b/src/__tests__/providerCollection.spec.ts
@@ -27,6 +27,7 @@ import { createApp } from "../app";
 const app = createApp();
 
 import { generateSTACCollections } from "../utils/testUtils";
+import { Link } from "../@types/StacCatalog";
 
 const emptyCollections = { facets: null, count: 0, cursor: "", items: [] };
 
@@ -94,22 +95,20 @@ describe("GET /:provider/collections", () => {
     });
   });
 
-  describe("given a provider with a collections containing STAC item APIs", () => {
-    it("returns collections with links of rel=items containing those API endpoints", async () => {
+  describe("given a provider with two collections, one of which is a collection containing a link to a STAC item API", () => {
+    it("returns collections with links of rel=items to the appropriate endpoints", async () => {
       sandbox
         .stub(Providers, "getProviders")
         .resolves([null, [{ "provider-id": "TEST", "short-name": "TEST" }]]);
 
       const mockCollections = generateSTACCollections(2);
 
-      // The first collection has a related URL of type 'GET CAPABILITIES' and subtype 'STAC'
       const link = {
         rel: "items",
         href: "https://brazildatacube.dpi.inpe.br/stac/collections/MOSAIC-S2-YANOMAMI-6M-1",
         type: "application/json",
       }
       mockCollections[0].links.push(link);
-      // The second collection does not have a STAC API related URL
 
       sandbox.stub(Collections, "getCollections").resolves({
         count: 2,
@@ -122,10 +121,13 @@ describe("GET /:provider/collections", () => {
 
       expect(statusCode).to.equal(200);
       expect(body.collections).to.have.lengthOf(2);
+      console.log(body.collections);
       // Get the links of rel=item for the first collection
-      //expect(body.collections[0]).to.equal(mockCollections[0].id);
+      const link0: Link = body.collections[0].links.find((l: Link) => l.rel === "items");
+      expect(link0.href).to.equal('https://brazildatacube.dpi.inpe.br/stac/collections/MOSAIC-S2-YANOMAMI-6M-1');
       // Get the links of rel=item for the second collection
-      //expect(body.collections[1].id).to.equal(mockCollections[1].id);
+      const link1: Link = body.collections[1].links.find((l: Link) => l.rel === "items");
+      expect(link1.href).to.contain('/stac/TEST/collections/');
     });
   });
 

--- a/src/__tests__/providerCollection.spec.ts
+++ b/src/__tests__/providerCollection.spec.ts
@@ -107,27 +107,28 @@ describe("GET /:provider/collections", () => {
         rel: "items",
         href: "https://brazildatacube.dpi.inpe.br/stac/collections/MOSAIC-S2-YANOMAMI-6M-1",
         type: "application/json",
-      }
+      };
       mockCollections[0].links.push(link);
 
       sandbox.stub(Collections, "getCollections").resolves({
         count: 2,
         cursor: null,
-        items: mockCollections
+        items: mockCollections,
       });
 
-      const { statusCode, body } = await request(app)
-        .get("/stac/TEST/collections");
+      const { statusCode, body } = await request(app).get("/stac/TEST/collections");
 
       expect(statusCode).to.equal(200);
       expect(body.collections).to.have.lengthOf(2);
 
       // Get the links of rel=item for the first collection
       const link0: Link = body.collections[0].links.find((l: Link) => l.rel === "items");
-      expect(link0.href).to.equal('https://brazildatacube.dpi.inpe.br/stac/collections/MOSAIC-S2-YANOMAMI-6M-1');
+      expect(link0.href).to.equal(
+        "https://brazildatacube.dpi.inpe.br/stac/collections/MOSAIC-S2-YANOMAMI-6M-1"
+      );
       // Get the links of rel=item for the second collection
       const link1: Link = body.collections[1].links.find((l: Link) => l.rel === "items");
-      expect(link1.href).to.contain('/stac/TEST/collections/');
+      expect(link1.href).to.contain("/stac/TEST/collections/");
     });
   });
 

--- a/src/__tests__/providerCollection.spec.ts
+++ b/src/__tests__/providerCollection.spec.ts
@@ -94,6 +94,41 @@ describe("GET /:provider/collections", () => {
     });
   });
 
+  describe("given a provider with a collections containing STAC item APIs", () => {
+    it("returns collections with links of rel=items containing those API endpoints", async () => {
+      sandbox
+        .stub(Providers, "getProviders")
+        .resolves([null, [{ "provider-id": "TEST", "short-name": "TEST" }]]);
+
+      const mockCollections = generateSTACCollections(2);
+
+      // The first collection has a related URL of type 'GET CAPABILITIES' and subtype 'STAC'
+      const link = {
+        rel: "items",
+        href: "https://brazildatacube.dpi.inpe.br/stac/collections/MOSAIC-S2-YANOMAMI-6M-1",
+        type: "application/json",
+      }
+      mockCollections[0].links.push(link);
+      // The second collection does not have a STAC API related URL
+
+      sandbox.stub(Collections, "getCollections").resolves({
+        count: 2,
+        cursor: null,
+        items: mockCollections
+      });
+
+      const { statusCode, body } = await request(app)
+        .get("/stac/TEST/collections");
+
+      expect(statusCode).to.equal(200);
+      expect(body.collections).to.have.lengthOf(2);
+      // Get the links of rel=item for the first collection
+      //expect(body.collections[0]).to.equal(mockCollections[0].id);
+      // Get the links of rel=item for the second collection
+      //expect(body.collections[1].id).to.equal(mockCollections[1].id);
+    });
+  });
+
   describe("datetime parameter", () => {
     it("should return collections within the specified datetime range", async () => {
       sandbox

--- a/src/domains/__tests__/collections.spec.ts
+++ b/src/domains/__tests__/collections.spec.ts
@@ -32,7 +32,6 @@ describe("getCollections", () => {
 describe("collectionsToStac", () => {
   describe("given a collection with a related url describing a STAC items endpoint", () => {
     it("should return a STAC collection with a link of relation 'items' pointing to that endpoint", () => {
-      
       const [base] = generateCollections(1);
       // Add in a related url as above
       const relatedUrl = {
@@ -41,59 +40,59 @@ describe("collectionsToStac", () => {
         type: "GET CAPABILITIES",
         subtype: "STAC",
         url: "https://data.inpe.br/bdc/stac/v1/collections/AMZ1-WFI-L4-SR-1",
-        getData: {       
-          format: "Not provided",       
-          mimeType: "application/json",       
-          size: 0.0,       
-          unit: "KB"     
-        }
-      }
+        getData: {
+          format: "Not provided",
+          mimeType: "application/json",
+          size: 0.0,
+          unit: "KB",
+        },
+      };
       base.relatedUrls?.push(relatedUrl);
 
       const stacCollection: any = collectionToStac(base);
 
       expect(stacCollection).to.have.deep.property("links", [
         {
-          rel: 'license',
-          href: 'https://science.nasa.gov/earth-science/earth-science-data/data-information-policy',
-          title: 'EOSDIS Data Use Policy',
-          type: 'text/html'
+          rel: "license",
+          href: "https://science.nasa.gov/earth-science/earth-science-data/data-information-policy",
+          title: "EOSDIS Data Use Policy",
+          type: "text/html",
         },
         {
-          rel: 'about',
-          href: 'undefined/search/concepts/C00000000-TEST_PROV.html',
-          title: 'HTML metadata for collection',
-          type: 'text/html'
+          rel: "about",
+          href: "undefined/search/concepts/C00000000-TEST_PROV.html",
+          title: "HTML metadata for collection",
+          type: "text/html",
         },
         {
-          rel: 'via',
-          href: 'undefined/search/concepts/C00000000-TEST_PROV.native',
-          title: 'Native metadata for collection',
-          type: 'application/xml'
+          rel: "via",
+          href: "undefined/search/concepts/C00000000-TEST_PROV.native",
+          title: "Native metadata for collection",
+          type: "application/xml",
         },
         {
-          rel: 'via',
-          href: 'undefined/search/concepts/C00000000-TEST_PROV.echo10',
-          title: 'ECHO10 metadata for collection',
-          type: 'application/echo10+xml'
+          rel: "via",
+          href: "undefined/search/concepts/C00000000-TEST_PROV.echo10",
+          title: "ECHO10 metadata for collection",
+          type: "application/echo10+xml",
         },
         {
-          rel: 'via',
-          href: 'undefined/search/concepts/C00000000-TEST_PROV.json',
-          title: 'CMR JSON metadata for collection',
-          type: 'application/json'
+          rel: "via",
+          href: "undefined/search/concepts/C00000000-TEST_PROV.json",
+          title: "CMR JSON metadata for collection",
+          type: "application/json",
         },
         {
-          rel: 'via',
-          href: 'undefined/search/concepts/C00000000-TEST_PROV.umm_json',
-          title: 'CMR UMM_JSON metadata for collection',
-          type: 'application/vnd.nasa.cmr.umm+json'
+          rel: "via",
+          href: "undefined/search/concepts/C00000000-TEST_PROV.umm_json",
+          title: "CMR UMM_JSON metadata for collection",
+          type: "application/vnd.nasa.cmr.umm+json",
         },
         {
-          rel: 'items',
-          href: 'https://data.inpe.br/bdc/stac/v1/collections/AMZ1-WFI-L4-SR-1',
-          type: 'application/json'
-        }
+          rel: "items",
+          href: "https://data.inpe.br/bdc/stac/v1/collections/AMZ1-WFI-L4-SR-1",
+          type: "application/json",
+        },
       ]);
     });
   });
@@ -105,49 +104,49 @@ describe("collectionsToStac", () => {
 
       expect(stacCollection).to.not.have.deep.property("links", [
         {
-          rel: 'license',
-          href: 'https://science.nasa.gov/earth-science/earth-science-data/data-information-policy',
-          title: 'EOSDIS Data Use Policy',
-          type: 'text/html'
+          rel: "license",
+          href: "https://science.nasa.gov/earth-science/earth-science-data/data-information-policy",
+          title: "EOSDIS Data Use Policy",
+          type: "text/html",
         },
         {
-          rel: 'about',
-          href: 'undefined/search/concepts/C00000000-TEST_PROV.html',
-          title: 'HTML metadata for collection',
-          type: 'text/html'
+          rel: "about",
+          href: "undefined/search/concepts/C00000000-TEST_PROV.html",
+          title: "HTML metadata for collection",
+          type: "text/html",
         },
         {
-          rel: 'via',
-          href: 'undefined/search/concepts/C00000000-TEST_PROV.native',
-          title: 'Native metadata for collection',
-          type: 'application/xml'
+          rel: "via",
+          href: "undefined/search/concepts/C00000000-TEST_PROV.native",
+          title: "Native metadata for collection",
+          type: "application/xml",
         },
         {
-          rel: 'via',
-          href: 'undefined/search/concepts/C00000000-TEST_PROV.echo10',
-          title: 'ECHO10 metadata for collection',
-          type: 'application/echo10+xml'
+          rel: "via",
+          href: "undefined/search/concepts/C00000000-TEST_PROV.echo10",
+          title: "ECHO10 metadata for collection",
+          type: "application/echo10+xml",
         },
         {
-          rel: 'via',
-          href: 'undefined/search/concepts/C00000000-TEST_PROV.json',
-          title: 'CMR JSON metadata for collection',
-          type: 'application/json'
+          rel: "via",
+          href: "undefined/search/concepts/C00000000-TEST_PROV.json",
+          title: "CMR JSON metadata for collection",
+          type: "application/json",
         },
         {
-          rel: 'via',
-          href: 'undefined/search/concepts/C00000000-TEST_PROV.umm_json',
-          title: 'CMR UMM_JSON metadata for collection',
-          type: 'application/vnd.nasa.cmr.umm+json'
+          rel: "via",
+          href: "undefined/search/concepts/C00000000-TEST_PROV.umm_json",
+          title: "CMR UMM_JSON metadata for collection",
+          type: "application/vnd.nasa.cmr.umm+json",
         },
         {
-          rel: 'items',
-          href: 'https://data.inpe.br/bdc/stac/v1/collections/AMZ1-WFI-L4-SR-1',
-          type: 'application/json'
-        }
+          rel: "items",
+          href: "https://data.inpe.br/bdc/stac/v1/collections/AMZ1-WFI-L4-SR-1",
+          type: "application/json",
+        },
       ]);
     });
-  });    
+  });
   describe("given a collection with S3 Links", () => {
     describe("given the S3 links are badly formatted with commas", () => {
       it("should return a STAC collection with the s3 links as assets", () => {

--- a/src/domains/__tests__/collections.spec.ts
+++ b/src/domains/__tests__/collections.spec.ts
@@ -9,6 +9,7 @@ const { expect } = chai;
 import * as gql from "graphql-request";
 import { getCollections, collectionToStac } from "../collections";
 import { generateCollections } from "../../utils/testUtils";
+import { UrlContentType } from "../../models/GraphQLModels";
 
 const sandbox = sinon.createSandbox();
 
@@ -29,6 +30,126 @@ describe("getCollections", () => {
 });
 
 describe("collectionsToStac", () => {
+  describe("given a collection with a related url describing a STAC items endpoint", () => {
+    it("should return a STAC collection with a link of relation 'items' pointing to that endpoint", () => {
+      
+      const [base] = generateCollections(1);
+      // Add in a related url as above
+      const relatedUrl = {
+        description: "foo",
+        urlContentType: UrlContentType.DISTRIBUTION_URL,
+        type: "GET CAPABILITIES",
+        subtype: "STAC",
+        url: "https://data.inpe.br/bdc/stac/v1/collections/AMZ1-WFI-L4-SR-1",
+        getData: {       
+          format: "Not provided",       
+          mimeType: "application/json",       
+          size: 0.0,       
+          unit: "KB"     
+        }
+      }
+      base.relatedUrls?.push(relatedUrl);
+
+      const stacCollection: any = collectionToStac(base);
+
+      console.log(stacCollection);
+
+      expect(stacCollection).to.have.deep.property("links", [
+        {
+          rel: 'license',
+          href: 'https://science.nasa.gov/earth-science/earth-science-data/data-information-policy',
+          title: 'EOSDIS Data Use Policy',
+          type: 'text/html'
+        },
+        {
+          rel: 'about',
+          href: 'undefined/search/concepts/C00000000-TEST_PROV.html',
+          title: 'HTML metadata for collection',
+          type: 'text/html'
+        },
+        {
+          rel: 'via',
+          href: 'undefined/search/concepts/C00000000-TEST_PROV.native',
+          title: 'Native metadata for collection',
+          type: 'application/xml'
+        },
+        {
+          rel: 'via',
+          href: 'undefined/search/concepts/C00000000-TEST_PROV.echo10',
+          title: 'ECHO10 metadata for collection',
+          type: 'application/echo10+xml'
+        },
+        {
+          rel: 'via',
+          href: 'undefined/search/concepts/C00000000-TEST_PROV.json',
+          title: 'CMR JSON metadata for collection',
+          type: 'application/json'
+        },
+        {
+          rel: 'via',
+          href: 'undefined/search/concepts/C00000000-TEST_PROV.umm_json',
+          title: 'CMR UMM_JSON metadata for collection',
+          type: 'application/vnd.nasa.cmr.umm+json'
+        },
+        {
+          rel: 'items',
+          href: 'https://data.inpe.br/bdc/stac/v1/collections/AMZ1-WFI-L4-SR-1',
+          type: 'application/json'
+        }
+      ]);
+    });
+  });
+  describe("given a collection without a related url describing a STAC items endpoint", () => {
+    it("should return a STAC collection without a link of relation 'items' pointing to that endpoint", () => {
+      const [base] = generateCollections(1);
+
+      const stacCollection: any = collectionToStac(base);
+
+      expect(stacCollection).to.not.have.deep.property("links", [
+        {
+          rel: 'license',
+          href: 'https://science.nasa.gov/earth-science/earth-science-data/data-information-policy',
+          title: 'EOSDIS Data Use Policy',
+          type: 'text/html'
+        },
+        {
+          rel: 'about',
+          href: 'undefined/search/concepts/C00000000-TEST_PROV.html',
+          title: 'HTML metadata for collection',
+          type: 'text/html'
+        },
+        {
+          rel: 'via',
+          href: 'undefined/search/concepts/C00000000-TEST_PROV.native',
+          title: 'Native metadata for collection',
+          type: 'application/xml'
+        },
+        {
+          rel: 'via',
+          href: 'undefined/search/concepts/C00000000-TEST_PROV.echo10',
+          title: 'ECHO10 metadata for collection',
+          type: 'application/echo10+xml'
+        },
+        {
+          rel: 'via',
+          href: 'undefined/search/concepts/C00000000-TEST_PROV.json',
+          title: 'CMR JSON metadata for collection',
+          type: 'application/json'
+        },
+        {
+          rel: 'via',
+          href: 'undefined/search/concepts/C00000000-TEST_PROV.umm_json',
+          title: 'CMR UMM_JSON metadata for collection',
+          type: 'application/vnd.nasa.cmr.umm+json'
+        },
+        {
+          rel: 'items',
+          href: 'https://data.inpe.br/bdc/stac/v1/collections/AMZ1-WFI-L4-SR-1',
+          type: 'application/json'
+        }
+      ]);
+    });
+  });    
   describe("given a collection with S3 Links", () => {
     describe("given the S3 links are badly formatted with commas", () => {
       it("should return a STAC collection with the s3 links as assets", () => {

--- a/src/domains/__tests__/collections.spec.ts
+++ b/src/domains/__tests__/collections.spec.ts
@@ -52,8 +52,6 @@ describe("collectionsToStac", () => {
 
       const stacCollection: any = collectionToStac(base);
 
-      console.log(stacCollection);
-
       expect(stacCollection).to.have.deep.property("links", [
         {
           rel: 'license',

--- a/src/domains/__tests__/collections.spec.ts
+++ b/src/domains/__tests__/collections.spec.ts
@@ -102,7 +102,7 @@ describe("collectionsToStac", () => {
 
       const stacCollection: any = collectionToStac(base);
 
-      expect(stacCollection).to.not.have.deep.property("links", [
+      expect(stacCollection).to.have.deep.property("links", [
         {
           rel: "license",
           href: "https://science.nasa.gov/earth-science/earth-science-data/data-information-policy",
@@ -138,11 +138,6 @@ describe("collectionsToStac", () => {
           href: "undefined/search/concepts/C00000000-TEST_PROV.umm_json",
           title: "CMR UMM_JSON metadata for collection",
           type: "application/vnd.nasa.cmr.umm+json",
-        },
-        {
-          rel: "items",
-          href: "https://data.inpe.br/bdc/stac/v1/collections/AMZ1-WFI-L4-SR-1",
-          type: "application/json",
         },
       ]);
     });

--- a/src/domains/collections.ts
+++ b/src/domains/collections.ts
@@ -98,25 +98,28 @@ const extractLicense = (_collection: Collection) => {
 };
 
 /**
- * Examing a collections related URLs to see if it contains a reference to a STAC catalog. 
+ * Examing a collections related URLs to see if it contains a reference to a STAC catalog.
  * If the collection has a RelatedURL of type: "GET CAPABILITIES",
  * and subtype: "STAC" then that URL should be placed in the href for the items link.
- *  
+ *
  * @param collection the collection object from a CMR GraphQL result
- * 
+ *
  * @returns a string representing the URL of the item Catalog described by the collection
  * or NULL if the related URL does not exist.
  */
 const itemCatalogUrl = (collection: Collection) => {
-  let catalog = null
+  let catalog = null;
   if (collection.relatedUrls != null) {
     for (const relatedUrl of collection.relatedUrls) {
-      if (relatedUrl.type == RelatedUrlType.GET_CAPABILITIES && relatedUrl.subtype == RelatedUrlSubType.STAC) {
-        catalog = relatedUrl.url
-        break
+      if (
+        relatedUrl.type == RelatedUrlType.GET_CAPABILITIES &&
+        relatedUrl.subtype == RelatedUrlSubType.STAC
+      ) {
+        catalog = relatedUrl.url;
+        break;
       }
     }
-    return catalog
+    return catalog;
   }
 };
 
@@ -154,14 +157,14 @@ const generateCollectionLinks = (collection: Collection, links: Links) => {
       type: "application/vnd.nasa.cmr.umm+json",
     },
   ];
-  /* A CMR collection can now indicate to consumers that it has a STAC API. 
+  /* A CMR collection can now indicate to consumers that it has a STAC API.
    * If that is the case then we use that link instead of a generic CMR one.
    * This is useful for collections that do not index their granule
    * metadata in CMR, like CWIC collection. If there is one present,
-   * it needs to be added as an 'item' link. If not, let browse.ts add a 
+   * it needs to be added as an 'item' link. If not, let browse.ts add a
    * generic one in CMR STAC
    */
-  const catalogUrl = itemCatalogUrl(collection)
+  const catalogUrl = itemCatalogUrl(collection);
   if (catalogUrl != null) {
     collectionLinks.push({
       rel: "items",

--- a/src/domains/collections.ts
+++ b/src/domains/collections.ts
@@ -108,6 +108,14 @@ const extractLicense = (_collection: Collection) => {
  * or NULL if the related URL does not exist.
  */
 const itemCatalogUrl = (collection: Collection) => {
+  const { relatedUrls } = collection;
+
+  const relatedUrl = relatedUrls?.find((relatedUrl) =>
+    relatedUrl.type == RelatedUrlType.GET_CAPABILITIES
+    && relatedUrl.subtype == RelatedUrlSubType.STAC
+  );
+  return relatedUrl?.url;
+};
   let catalog = null;
   if (collection.relatedUrls != null) {
     for (const relatedUrl of collection.relatedUrls) {

--- a/src/domains/collections.ts
+++ b/src/domains/collections.ts
@@ -116,20 +116,6 @@ const itemCatalogUrl = (collection: Collection) => {
   );
   return relatedUrl?.url;
 };
-  let catalog = null;
-  if (collection.relatedUrls != null) {
-    for (const relatedUrl of collection.relatedUrls) {
-      if (
-        relatedUrl.type == RelatedUrlType.GET_CAPABILITIES &&
-        relatedUrl.subtype == RelatedUrlSubType.STAC
-      ) {
-        catalog = relatedUrl.url;
-        break;
-      }
-    }
-    return catalog;
-  }
-};
 
 const generateCollectionLinks = (collection: Collection, links: Links) => {
   const collectionLinks = [

--- a/src/domains/collections.ts
+++ b/src/domains/collections.ts
@@ -10,6 +10,8 @@ import {
   CollectionsInput,
   GraphQLHandler,
   GraphQLResults,
+  RelatedUrlType,
+  RelatedUrlSubType,
 } from "../models/GraphQLModels";
 
 import { cmrSpatialToExtent } from "./bounding-box";
@@ -109,7 +111,7 @@ const itemCatalogUrl = (collection: Collection) => {
   let catalog = null
   if (collection.relatedUrls != null) {
     for (const relatedUrl of collection.relatedUrls) {
-      if (relatedUrl.type == 'GET CAPABILITIES' && relatedUrl.subtype == 'STAC') {
+      if (relatedUrl.type == RelatedUrlType.GET_CAPABILITIES && relatedUrl.subtype == RelatedUrlSubType.STAC) {
         catalog = relatedUrl.url
         break
       }
@@ -152,9 +154,13 @@ const generateCollectionLinks = (collection: Collection, links: Links) => {
       type: "application/vnd.nasa.cmr.umm+json",
     },
   ];
-  // Collection may have a STAC catalog defined in their metadata. If there is one present,
-  // it needs to be added as an 'item' link. If not, let browse.ts add a generic one in 
-  // CMR STAC.
+  /* A CMR collection can now indicate to consumers that it has a STAC API. 
+   * If that is the case then we use that link instead of a generic CMR one.
+   * This is useful for collections that do not index their granule
+   * metadata in CMR, like CWIC collection. If there is one present,
+   * it needs to be added as an 'item' link. If not, let browse.ts add a 
+   * generic one in CMR STAC
+   */
   const catalogUrl = itemCatalogUrl(collection)
   if (catalogUrl != null) {
     collectionLinks.push({

--- a/src/domains/collections.ts
+++ b/src/domains/collections.ts
@@ -110,9 +110,10 @@ const extractLicense = (_collection: Collection) => {
 const itemCatalogUrl = (collection: Collection) => {
   const { relatedUrls } = collection;
 
-  const relatedUrl = relatedUrls?.find((relatedUrl) =>
-    relatedUrl.type == RelatedUrlType.GET_CAPABILITIES
-    && relatedUrl.subtype == RelatedUrlSubType.STAC
+  const relatedUrl = relatedUrls?.find(
+    (relatedUrl) =>
+      relatedUrl.type == RelatedUrlType.GET_CAPABILITIES &&
+      relatedUrl.subtype == RelatedUrlSubType.STAC
   );
   return relatedUrl?.url;
 };

--- a/src/models/GraphQLModels.ts
+++ b/src/models/GraphQLModels.ts
@@ -92,6 +92,7 @@ export enum RelatedUrlSubType {
   DATA_TREE = "DATA TREE",
   EARTHDATA_SEARCH = "Earthdata Search",
   GIOVANNI = "GIOVANNI",
+  STAC = "STAC",
 }
 
 export type UseConstraints =

--- a/src/routes/browse.ts
+++ b/src/routes/browse.ts
@@ -78,7 +78,12 @@ export const collectionsHandler = async (req: Request, res: Response): Promise<v
       href: encodeURI(stacRoot),
       type: "application/json",
     });
-    // If the list of links of does not contain a link of type 'items' then add the default items element
+    /* A CMR collection can now indicate to consumers that it has a STAC API. 
+     * If that is the case then we use that link instead of a generic CMR one.
+     * This is useful of collections that do not index their granule
+     * metadata in CMR, like CWIC colle ction.
+     * If the list of links of does not contain a link of type 'items' then add the default items element 
+     */
     let itemsPresent = false
     for (const link of collection.links) {
       if (link.rel == 'items') {

--- a/src/routes/browse.ts
+++ b/src/routes/browse.ts
@@ -87,7 +87,7 @@ export const collectionsHandler = async (req: Request, res: Response): Promise<v
      */
     const { links } = collection;
 
-    const itemsLink = links.find((link) => link.rel === 'items');
+    const itemsLink = links.find((link) => link.rel === "items");
 
     if (!itemsLink) {
       collection.links.push({

--- a/src/routes/browse.ts
+++ b/src/routes/browse.ts
@@ -78,18 +78,18 @@ export const collectionsHandler = async (req: Request, res: Response): Promise<v
       href: encodeURI(stacRoot),
       type: "application/json",
     });
-    /* A CMR collection can now indicate to consumers that it has a STAC API. 
+    /* A CMR collection can now indicate to consumers that it has a STAC API.
      * If that is the case then we use that link instead of a generic CMR one.
      * This is useful of collections that do not index their granule
      * metadata in CMR, like CWIC collection.
-     * If the list of links of does not contain a link of type 'items' then 
-     * add the default items element 
+     * If the list of links of does not contain a link of type 'items' then
+     * add the default items element
      */
-    let itemsPresent = false
+    let itemsPresent = false;
     for (const link of collection.links) {
-      if (link.rel == 'items') {
-        itemsPresent = true
-        break
+      if (link.rel == "items") {
+        itemsPresent = true;
+        break;
       }
     }
     if (itemsPresent == false) {

--- a/src/routes/browse.ts
+++ b/src/routes/browse.ts
@@ -81,8 +81,9 @@ export const collectionsHandler = async (req: Request, res: Response): Promise<v
     /* A CMR collection can now indicate to consumers that it has a STAC API. 
      * If that is the case then we use that link instead of a generic CMR one.
      * This is useful of collections that do not index their granule
-     * metadata in CMR, like CWIC colle ction.
-     * If the list of links of does not contain a link of type 'items' then add the default items element 
+     * metadata in CMR, like CWIC collection.
+     * If the list of links of does not contain a link of type 'items' then 
+     * add the default items element 
      */
     let itemsPresent = false
     for (const link of collection.links) {

--- a/src/routes/browse.ts
+++ b/src/routes/browse.ts
@@ -87,16 +87,9 @@ export const collectionsHandler = async (req: Request, res: Response): Promise<v
      */
     const { links } = collection;
 
-    const itemsPresent = links.find((link) => link.rel === 'items');
+    const itemsLink = links.find((link) => link.rel === 'items');
 
-    if (!itemsPresent) {```
-    for (const link of collection.links) {
-      if (link.rel == "items") {
-        itemsPresent = true;
-        break;
-      }
-    }
-    if (itemsPresent == false) {
+    if (!itemsLink) {
       collection.links.push({
         rel: "items",
         href: `${baseUrl}/${encodeURIComponent(collection.id)}/items`,

--- a/src/routes/browse.ts
+++ b/src/routes/browse.ts
@@ -86,9 +86,7 @@ export const collectionsHandler = async (req: Request, res: Response): Promise<v
         break
       }
     }
-    console.log("I am in browse!");
     if (itemsPresent == false) {
-      console.log("I am adding!");
       collection.links.push({
         rel: "items",
         href: `${baseUrl}/${encodeURIComponent(collection.id)}/items`,

--- a/src/routes/browse.ts
+++ b/src/routes/browse.ts
@@ -85,7 +85,11 @@ export const collectionsHandler = async (req: Request, res: Response): Promise<v
      * If the list of links of does not contain a link of type 'items' then
      * add the default items element
      */
-    let itemsPresent = false;
+    const { links } = collection;
+
+    const itemsPresent = links.find((link) => link.rel === 'items');
+
+    if (!itemsPresent) {```
     for (const link of collection.links) {
       if (link.rel == "items") {
         itemsPresent = true;

--- a/src/routes/browse.ts
+++ b/src/routes/browse.ts
@@ -78,11 +78,23 @@ export const collectionsHandler = async (req: Request, res: Response): Promise<v
       href: encodeURI(stacRoot),
       type: "application/json",
     });
-    collection.links.push({
-      rel: "items",
-      href: `${baseUrl}/${encodeURIComponent(collection.id)}/items`,
-      type: "application/json",
-    });
+    // If the list of links of does not contain a link of type 'items' then add the default items element
+    let itemsPresent = false
+    for (const link of collection.links) {
+      if (link.rel == 'items') {
+        itemsPresent = true
+        break
+      }
+    }
+    console.log("I am in browse!");
+    if (itemsPresent == false) {
+      console.log("I am adding!");
+      collection.links.push({
+        rel: "items",
+        href: `${baseUrl}/${encodeURIComponent(collection.id)}/items`,
+        type: "application/json",
+      });
+    }
   });
 
   const links = collectionLinks(req, cursor);


### PR DESCRIPTION
https://bugs.earthdata.nasa.gov/browse/CMR-10184

A CMR collection can now indicate to consumers that it has a STAC API. 
If that is the case then we should use that link instead of a generic one inserted at runtime.
This is useful of collections that do not index their granule metadata in CMR, like CWIC collections.