### PR TITLE
CMR-10186: Handling case when collections query parameter is a comma separated string

### DIFF
--- a/src/domains/__tests__/stac.spec.ts
+++ b/src/domains/__tests__/stac.spec.ts
@@ -573,6 +573,23 @@ describe("conversions to GraphQL", () => {
       });
     });
 
+    describe("given multiple collection identifiers as a comma separated string", () => {
+      it("should separate the entryIds properly", async () => {
+        expect(
+          await buildQuery({
+            method: "GET",
+            url: "/stac/PROV/search",
+            headers: {},
+            params: { providerId: "PROV" },
+            query: { collections: "coll_v1,coll_v2" },
+          } as any)
+        ).to.deep.equal({
+          provider: "PROV",
+          entryId: ["coll_v1", "coll_v2"],
+        });
+      });
+    });
+
     describe("given an id as part of the path", () => {
       it("should not modify them", async () => {
         expect(

--- a/src/domains/stac.ts
+++ b/src/domains/stac.ts
@@ -468,7 +468,7 @@ const collectionsQuery = async (req: Request, query: StacQuery): Promise<{ entry
   // query.collections could be a comma separated string of multiple collections.
   // Need to ensure this would be split out appropriately.
   if (query.collections && !Array.isArray(query.collections)) {
-    query.collections = query.collections.split(',');
+    query.collections = query.collections.split(",");
   }
 
   const collections = Array.isArray(query.collections)

--- a/src/domains/stac.ts
+++ b/src/domains/stac.ts
@@ -465,6 +465,12 @@ const collectionsQuery = async (req: Request, query: StacQuery): Promise<{ entry
   } = req;
   const cloudHosted = headers["cloud-stac"] === "true";
 
+  // query.collections could be a comma separated string of multiple collections.
+  // Need to ensure this would be split out appropriately.
+  if (query.collections && !Array.isArray(query.collections)) {
+    query.collections = query.collections.split(',');
+  }
+
   const collections = Array.isArray(query.collections)
     ? [...query.collections, collectionId]
     : [query.collections, collectionId];


### PR DESCRIPTION
CMR-STAC was passing the collections query parameter as is to graphQL which resulting in a comma separated string as an entryID, ie: "entryId": [ "HLSS30_2.0,HLSL30_2.0" ]. In this case CMR-STAC would return nothing.
This needs to be split properly so that the field passed the graphQL would be of the form "entryId": [ "HLSS30_2.0", "HLSL30_2.0" ]

Example GET Requests:
https://cmr.earthdata.nasa.gov/stac/LPCLOUD/search?collections=HLSS30_2.0,HLSL30_2.0
http://localhost:3000/stac/LPCLOUD/search?collections=HLSS30_2.0,HLSL30_2.0

Specifying multiple collections in this manner should return the proper results
