### PR TITLE
CMR-10221: Fixed double-rendering of items in browse route.

### DIFF
--- a/src/__tests__/providerCollection.spec.ts
+++ b/src/__tests__/providerCollection.spec.ts
@@ -105,8 +105,8 @@ describe("GET /:provider/collections", () => {
 
       const link = {
         rel: "items",
-        href: "https://brazildatacube.dpi.inpe.br/stac/collections/MOSAIC-S2-YANOMAMI-6M-1",
-        type: "application/json",
+        href: "https://brazildatacube.dpi.inpe.br/stac/collections/MOSAIC-S2-YANOMAMI-6M-1/items",
+        type: "application/geo+json",
       };
       mockCollections[0].links.push(link);
 
@@ -121,12 +121,17 @@ describe("GET /:provider/collections", () => {
       expect(statusCode).to.equal(200);
       expect(body.collections).to.have.lengthOf(2);
 
-      // Get the links of rel=item for the first collection
+      // Expect there to be one link with rel=items
+      expect(body.collections[0].links.filter((l: Link) => l.rel === "items")).to.have.lengthOf(1);
+      // Expect the href to match the STAC API described.
       const link0: Link = body.collections[0].links.find((l: Link) => l.rel === "items");
       expect(link0.href).to.equal(
-        "https://brazildatacube.dpi.inpe.br/stac/collections/MOSAIC-S2-YANOMAMI-6M-1"
+        "https://brazildatacube.dpi.inpe.br/stac/collections/MOSAIC-S2-YANOMAMI-6M-1/items"
       );
-      // Get the links of rel=item for the second collection
+
+      // Expect there to be on lin with rel=items
+      expect(body.collections[1].links.filter((l: Link) => l.rel === "items")).to.have.lengthOf(1);
+      // Expect the href to match the generic STAC API.
       const link1: Link = body.collections[1].links.find((l: Link) => l.rel === "items");
       expect(link1.href).to.contain("/stac/TEST/collections/");
     });

--- a/src/__tests__/providerCollection.spec.ts
+++ b/src/__tests__/providerCollection.spec.ts
@@ -129,7 +129,7 @@ describe("GET /:provider/collections", () => {
         "https://brazildatacube.dpi.inpe.br/stac/collections/MOSAIC-S2-YANOMAMI-6M-1/items"
       );
 
-      // Expect there to be on lin with rel=items
+      // Expect there to be on line with rel=items
       expect(body.collections[1].links.filter((l: Link) => l.rel === "items")).to.have.lengthOf(1);
       // Expect the href to match the generic STAC API.
       const link1: Link = body.collections[1].links.find((l: Link) => l.rel === "items");

--- a/src/domains/__tests__/collections.spec.ts
+++ b/src/domains/__tests__/collections.spec.ts
@@ -9,7 +9,7 @@ const { expect } = chai;
 import * as gql from "graphql-request";
 import { getCollections, collectionToStac } from "../collections";
 import { generateCollections } from "../../utils/testUtils";
-import { UrlContentType } from "../../models/GraphQLModels";
+import { UrlContentType, RelatedUrlType, RelatedUrlSubType } from "../../models/GraphQLModels";
 
 const sandbox = sinon.createSandbox();
 
@@ -37,9 +37,9 @@ describe("collectionsToStac", () => {
       const relatedUrl = {
         description: "foo",
         urlContentType: UrlContentType.DISTRIBUTION_URL,
-        type: "GET CAPABILITIES",
-        subtype: "STAC",
-        url: "https://data.inpe.br/bdc/stac/v1/collections/AMZ1-WFI-L4-SR-1",
+        type: RelatedUrlType.GET_CAPABILITIES,
+        subtype: RelatedUrlSubType.STAC,
+        url: "https://data.inpe.br/bdc/stac/v1/collections/AMZ1-WFI-L4-SR-1/items",
         getData: {
           format: "Not provided",
           mimeType: "application/json",
@@ -90,8 +90,8 @@ describe("collectionsToStac", () => {
         },
         {
           rel: "items",
-          href: "https://data.inpe.br/bdc/stac/v1/collections/AMZ1-WFI-L4-SR-1",
-          type: "application/json",
+          href: "https://data.inpe.br/bdc/stac/v1/collections/AMZ1-WFI-L4-SR-1/items",
+          type: "application/geo+json",
         },
       ]);
     });

--- a/src/domains/__tests__/collections.spec.ts
+++ b/src/domains/__tests__/collections.spec.ts
@@ -91,6 +91,7 @@ describe("collectionsToStac", () => {
         {
           rel: "items",
           href: "https://data.inpe.br/bdc/stac/v1/collections/AMZ1-WFI-L4-SR-1/items",
+          title: "Collection Items",
           type: "application/geo+json",
         },
       ]);

--- a/src/domains/collections.ts
+++ b/src/domains/collections.ts
@@ -164,6 +164,7 @@ const generateCollectionLinks = (collection: Collection, links: Links) => {
       rel: "items",
       href: catalogUrl,
       type: "application/geo+json",
+      title: "Collection Items",
     });
   }
   return collectionLinks;

--- a/src/domains/collections.ts
+++ b/src/domains/collections.ts
@@ -150,7 +150,8 @@ const generateCollectionLinks = (collection: Collection, links: Links) => {
       type: "application/vnd.nasa.cmr.umm+json",
     },
   ];
-  /* A CMR collection can now indicate to consumers that it has a STAC API.
+  /**
+   * A CMR collection can now indicate to consumers that it has a STAC API.
    * If that is the case then we use that link instead of a generic CMR one.
    * This is useful for collections that do not index their granule
    * metadata in CMR, like CWIC collection. If there is one present,
@@ -162,7 +163,7 @@ const generateCollectionLinks = (collection: Collection, links: Links) => {
     collectionLinks.push({
       rel: "items",
       href: catalogUrl,
-      type: "application/json",
+      type: "application/geo+json",
     });
   }
   return collectionLinks;

--- a/src/routes/__tests__/browse.spec.ts
+++ b/src/routes/__tests__/browse.spec.ts
@@ -1,0 +1,89 @@
+import * as sinon from "sinon";
+import chai from "chai";
+import sinonChai from "sinon-chai";
+
+chai.use(sinonChai);
+
+const { expect } = chai;
+
+import * as gql from "graphql-request";
+import { collectionHandler, collectionsHandler, addItemLinkIfPresent } from "../browse";
+import { generateSTACCollections } from "../../utils/testUtils";
+
+const sandbox = sinon.createSandbox();
+
+afterEach(() => {
+  sandbox.restore();
+});
+
+describe("addItemLinkIfPresent", () => {
+  it("will add an item link if no item link is present", async () => {
+    // Create a STACCollection with no item link
+    let stacCollection = generateSTACCollections(1)[0];
+    // Add a non-item link
+    stacCollection.links.push({
+      rel: "via",
+      href: "https://example.com/foo",
+      type: "application/html",
+      title: "foo",
+    });
+
+    const numberoOfLinks = stacCollection.links.length;
+    // Invoke method
+    addItemLinkIfPresent(stacCollection, "https://foo.com/items");
+    // Observe an addiitonal link in the STAC Collection with rel=items etc.
+    expect(stacCollection.links.length).to.equal(numberoOfLinks + 1);
+    expect(stacCollection).to.have.deep.property("links", [
+      {
+        rel: "via",
+        href: "https://example.com/foo",
+        type: "application/html",
+        title: "foo",
+      },
+      {
+        rel: "items",
+        href: "https://foo.com/items",
+        type: "application/geo+json",
+        title: "Collection Items",
+      },
+    ]);
+  });
+  it("will not add an item link if an item link is present", async () => {
+    // Create a STACCollection with no item link
+    let stacCollection = generateSTACCollections(1)[0];
+
+    // Manually add an item link
+    stacCollection.links.push({
+      rel: "items",
+      href: "https://example.com/items",
+      type: "application/geo+json",
+      title: "Collection Items",
+    });
+    // Add a non-item link
+    stacCollection.links.push({
+      rel: "via",
+      href: "https://example.com/foo",
+      type: "application/html",
+      title: "foo",
+    });
+    const numberoOfLinks = stacCollection.links.length;
+    // Invoke method
+    addItemLinkIfPresent(stacCollection, "https://foo.com/items");
+    // Observe no addiitonal link in the STAC Collection and that the item link remains a CMR link
+    expect(stacCollection.links.length).to.equal(numberoOfLinks);
+    expect(stacCollection).to.have.deep.property("links", [
+      {
+        rel: "items",
+        href: "https://example.com/items",
+        type: "application/geo+json",
+        title: "Collection Items",
+      },
+      {
+        rel: "via",
+        href: "https://example.com/foo",
+        type: "application/html",
+        title: "foo",
+      },
+    ]);
+  });
+});

--- a/src/routes/__tests__/browse.spec.ts
+++ b/src/routes/__tests__/browse.spec.ts
@@ -10,12 +10,6 @@ import * as gql from "graphql-request";
 import { collectionHandler, collectionsHandler, addItemLinkIfPresent } from "../browse";
 import { generateSTACCollections } from "../../utils/testUtils";
 
-const sandbox = sinon.createSandbox();
-
-afterEach(() => {
-  sandbox.restore();
-});
-
 describe("addItemLinkIfPresent", () => {
   it("will add an item link if no item link is present", async () => {
     // Create a STACCollection with no item link

--- a/src/routes/browse.ts
+++ b/src/routes/browse.ts
@@ -121,7 +121,7 @@ export const collectionHandler = async (req: Request, res: Response): Promise<vo
  *  @param url the generic link to a CMR STAC API
  */
 
-function addItemLinkIfPresent(collection: STACCollection, url: string) {
+export function addItemLinkIfPresent(collection: STACCollection, url: string) {
   const itemsLink = collection.links.find((link) => link.rel === "items");
 
   if (!itemsLink) {

--- a/src/routes/browse.ts
+++ b/src/routes/browse.ts
@@ -48,7 +48,6 @@ const collectionLinks = (req: Request, nextCursor?: string | null): Links => {
 };
 
 export const collectionsHandler = async (req: Request, res: Response): Promise<void> => {
-  console.debug("XXXXXXX collectionsHandler");
   const { headers } = req;
 
   const query = await buildQuery(req);
@@ -89,7 +88,6 @@ export const collectionsHandler = async (req: Request, res: Response): Promise<v
  * Returns a STACCollection as the body.
  */
 export const collectionHandler = async (req: Request, res: Response): Promise<void> => {
-  console.debug("XXXXXXX collectionHandler");
   const {
     collection,
     params: { collectionId, providerId },


### PR DESCRIPTION
The browse route will now only render one link with rel=item.
If the collection has a curator-supplied STAC API it will use that as the link, otherwise it will insert the generic CMR-STAC based one.
Added unit tests for browse.ts (there needs to be a lot more for existing functionality)