### PR TITLE
CMR-10242: Fix `/items`/ path for collections which have granule metadata

### DIFF
--- a/src/routes/__tests__/browse.spec.ts
+++ b/src/routes/__tests__/browse.spec.ts
@@ -24,7 +24,7 @@ describe("addItemLinkIfPresent", () => {
 
     const numberoOfLinks = stacCollection.links.length;
     // Invoke method
-    addItemLinkIfPresent(stacCollection, "https://foo.com/items");
+    addItemLinkIfPresent(stacCollection, "https://foo.com");
     // Observe an addiitonal link in the STAC Collection with rel=items etc.
     expect(stacCollection.links.length).to.equal(numberoOfLinks + 1);
     expect(stacCollection).to.have.deep.property("links", [

--- a/src/routes/browse.ts
+++ b/src/routes/browse.ts
@@ -127,7 +127,7 @@ export function addItemLinkIfPresent(collection: STACCollection, url: string) {
   if (!itemsLink) {
     collection.links.push({
       rel: "items",
-      href: url + '/items',
+      href: `${url}/items`,
       type: "application/geo+json",
       title: "Collection Items",
     });

--- a/src/routes/browse.ts
+++ b/src/routes/browse.ts
@@ -69,7 +69,6 @@ export const collectionsHandler = async (req: Request, res: Response): Promise<v
       href: encodeURI(stacRoot),
       type: "application/json",
     });
-    console.debug("collectionsHandler");
     addItemLinkIfPresent(collection, `${getBaseUrl(self)}/${encodeURIComponent(collection.id)}`);
   });
 
@@ -103,7 +102,6 @@ export const collectionHandler = async (req: Request, res: Response): Promise<vo
     ? [...collectionLinks(req), ...(collection.links ?? [])]
     : [...collectionLinks(req)];
   const { path } = stacContext(req);
-  console.debug("collectionHandler");
   addItemLinkIfPresent(collection, path);
   res.json(collection);
 };
@@ -121,7 +119,6 @@ export const collectionHandler = async (req: Request, res: Response): Promise<vo
  */
 
 export function addItemLinkIfPresent(collection: STACCollection, url: string) {
-  console.debug("addItemLinkIfPresent: URL: " + url);
   const itemsLink = collection.links.find((link) => link.rel === "items");
 
   if (!itemsLink) {

--- a/src/routes/browse.ts
+++ b/src/routes/browse.ts
@@ -69,7 +69,7 @@ export const collectionsHandler = async (req: Request, res: Response): Promise<v
       href: encodeURI(stacRoot),
       type: "application/json",
     });
-
+    console.debug("collectionsHandler");
     addItemLinkIfPresent(collection, `${getBaseUrl(self)}/${encodeURIComponent(collection.id)}`);
   });
 
@@ -103,6 +103,7 @@ export const collectionHandler = async (req: Request, res: Response): Promise<vo
     ? [...collectionLinks(req), ...(collection.links ?? [])]
     : [...collectionLinks(req)];
   const { path } = stacContext(req);
+  console.debug("collectionHandler");
   addItemLinkIfPresent(collection, path);
   res.json(collection);
 };
@@ -120,12 +121,13 @@ export const collectionHandler = async (req: Request, res: Response): Promise<vo
  */
 
 export function addItemLinkIfPresent(collection: STACCollection, url: string) {
+  console.debug("addItemLinkIfPresent: URL: " + url);
   const itemsLink = collection.links.find((link) => link.rel === "items");
 
   if (!itemsLink) {
     collection.links.push({
       rel: "items",
-      href: url,
+      href: url + '/items',
       type: "application/geo+json",
       title: "Collection Items",
     });


### PR DESCRIPTION
The /items path was missing from rel=items links belonging to collections who have granule metadata in CMR. This resolves that problem. Needs to be addressed before the next release to UAT.