### PR TITLE
CMR-10146: Making sure validBbox compares numbers and not strings

### DIFF
--- a/src/middleware/__tests__/index.spec.ts
+++ b/src/middleware/__tests__/index.spec.ts
@@ -4,32 +4,31 @@ const { expect } = chai;
 import { validBbox } from "../index";
 
 describe("validBBOX", () => {
-    describe("when bbox is a string", () => {
-        it("returns a valid bbox", async () => {
-            const bbox = "-122.09,39.89,-122.03,39.92"
-            expect(validBbox(bbox)).to.equal(true);
-        });
+  describe("when bbox is a string", () => {
+    it("returns a valid bbox", async () => {
+      const bbox = "-122.09,39.89,-122.03,39.92";
+      expect(validBbox(bbox)).to.equal(true);
     });
+  });
 
-    describe("when bbox is a string array", () => {
-        it("returns a valid bbox", async () => {
-            const bbox = ["-122.09","39.89","-122.03","39.92"]
-            expect(validBbox(bbox)).to.equal(true);
-        });
+  describe("when bbox is a string array", () => {
+    it("returns a valid bbox", async () => {
+      const bbox = ["-122.09", "39.89", "-122.03", "39.92"];
+      expect(validBbox(bbox)).to.equal(true);
     });
+  });
 
-    describe("when bbox is an invalid string array with negative numbers", () => {
-        it("returns an invalid bbox", async () => {
-            const bbox = ["-122.03","39.89","-122.09","39.92"]
-            expect(validBbox(bbox)).to.equal(false);
-        });
+  describe("when bbox is an invalid string array with negative numbers", () => {
+    it("returns an invalid bbox", async () => {
+      const bbox = ["-122.03", "39.89", "-122.09", "39.92"];
+      expect(validBbox(bbox)).to.equal(false);
     });
+  });
 
-    describe("when bbox is a number array", () => {
-        it("returns a valid bbox", async () => {
-            const bbox = [ -122.09, 39.89, -122.03, 39.92 ]
-            expect(validBbox(bbox)).to.equal(true);
-        });
+  describe("when bbox is a number array", () => {
+    it("returns a valid bbox", async () => {
+      const bbox = [-122.09, 39.89, -122.03, 39.92];
+      expect(validBbox(bbox)).to.equal(true);
     });
-
+  });
 });

--- a/src/middleware/__tests__/index.spec.ts
+++ b/src/middleware/__tests__/index.spec.ts
@@ -1,0 +1,35 @@
+import chai from "chai";
+const { expect } = chai;
+
+import { validBbox } from "../index";
+
+describe("validBBOX", () => {
+    describe("when bbox is a string", () => {
+        it("returns a valid bbox", async () => {
+            const bbox = "-122.09,39.89,-122.03,39.92"
+            expect(validBbox(bbox)).to.equal(true);
+        });
+    });
+
+    describe("when bbox is a string array", () => {
+        it("returns a valid bbox", async () => {
+            const bbox = ["-122.09","39.89","-122.03","39.92"]
+            expect(validBbox(bbox)).to.equal(true);
+        });
+    });
+
+    describe("when bbox is an invalid string array with negative numbers", () => {
+        it("returns an invalid bbox", async () => {
+            const bbox = ["-122.03","39.89","-122.09","39.92"]
+            expect(validBbox(bbox)).to.equal(false);
+        });
+    });
+
+    describe("when bbox is a number array", () => {
+        it("returns a valid bbox", async () => {
+            const bbox = [ -122.09, 39.89, -122.03, 39.92 ]
+            expect(validBbox(bbox)).to.equal(true);
+        });
+    });
+
+});

--- a/src/middleware/index.ts
+++ b/src/middleware/index.ts
@@ -190,7 +190,10 @@ const validLat = (lat: number) => inclusiveBetween(lat, -90.0, 90.0);
 
 const validLon = (lon: number) => inclusiveBetween(lon, -180.0, 180.0);
 
-const validBbox = (bbox: string | number[]) => {
+// validBbox should be able to accept a comma separated string, a string array and
+// a number array. We noticed the string array should be accepted when running the
+// R Stac script.
+export const validBbox = (bbox: string | string[] | number[]) => {
   const parsedBbox = typeof bbox === "string" ? parseOrdinateString(bbox) : bbox;
 
   if (parsedBbox.length !== 4 && parsedBbox.length !== 6) return false;
@@ -201,11 +204,12 @@ const validBbox = (bbox: string | number[]) => {
   } else {
     [swLon, swLat, , neLon, neLat] = parsedBbox;
   }
+
   return (
-    validLon(swLon) &&
-    validLat(swLat) &&
-    validLon(neLon) &&
-    validLat(neLat) &&
+    validLon(Number(swLon)) &&
+    validLat(Number(swLat)) &&
+    validLon(Number(neLon)) &&
+    validLat(Number(neLat)) &&
     // Ensure that number comparisons are used instead of string comparisons
     Number(swLat) <= Number(neLat) &&
     Number(swLon) <= Number(neLon)

--- a/src/middleware/index.ts
+++ b/src/middleware/index.ts
@@ -206,6 +206,7 @@ const validBbox = (bbox: string | number[]) => {
     validLat(swLat) &&
     validLon(neLon) &&
     validLat(neLat) &&
+    // Ensure that number comparisons are used instead of string comparisons
     Number(swLat) <= Number(neLat) &&
     Number(swLon) <= Number(neLon)
   );

--- a/src/middleware/index.ts
+++ b/src/middleware/index.ts
@@ -206,8 +206,8 @@ const validBbox = (bbox: string | number[]) => {
     validLat(swLat) &&
     validLon(neLon) &&
     validLat(neLat) &&
-    swLat <= neLat &&
-    swLon <= neLon
+    Number(swLat) <= Number(neLat) &&
+    Number(swLon) <= Number(neLon)
   );
 };
 


### PR DESCRIPTION
# Overview

### What is the feature?

CMR-STAC's validBbox function may be passed an array of strings. In this case, the comparison between points does a comparison with strings. When negative numbers are used, comparing negative numbers as strings doesnt work properly.

### What is the Solution?

Need to cast the comparison as numbers so numerical comparison is used instead of string comparison.(for negative numbers)

### What areas of the application does this impact?

When a bbox array of string is passed in.

# Testing

### Reproduction steps

- **Environment for testing:**
- **Collection to test with:**

Can use the following url to test:
https://cmr.earthdata.nasa.gov/stac/LPCLOUD/search?bbox[0]=-122.09&bbox[1]=39.89&bbox[2]=-122.03&bbox[3]=39.92&datetime=2024-01-01T00:00:00Z/2024-09-24T00:00:00Z&limit=1&collections=HLSL30_2.0

Currently getting an error as follows:
{"errors":["BBOX must be in the form of 'bbox=swLon,swLat,neLon,neLat' with valid latitude and longitude."]}

### Attachments
<img width="871" alt="Screenshot 2024-11-13 at 5 55 09 PM" src="https://github.com/user-attachments/assets/827da7ca-376f-4d75-97c8-2a3be328b451">
Showing R STAC script not working

<img width="870" alt="Screenshot 2024-11-13 at 5 53 41 PM" src="https://github.com/user-attachments/assets/cdf36e48-8ba6-41cc-860b-64716a54586b">
Showing R STAC script working

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

