### PR TITLE
CMR-10238: Adding the virtual catalog 'ALL'

### DIFF
--- a/src/@types/StacCollection.d.ts
+++ b/src/@types/StacCollection.d.ts
@@ -187,7 +187,7 @@ export type STACCollection = {
   description: Description;
   keywords?: Keywords;
   license: CollectionLicenseName;
-  providers?: {
+  providers: {
     name: OrganizationName;
     description?: OrganizationDescription;
     roles?: OrganizationRoles;

--- a/src/__tests__/items.spec.ts
+++ b/src/__tests__/items.spec.ts
@@ -172,3 +172,33 @@ describe("GET /PROVIDER/collections/COLLECTION/items/ITEM", () => {
     });
   });
 });
+
+describe("GET /ALL/collections/:collection/items/", () => {
+  it("should return a 404", async () => {
+    sandbox
+      .stub(Providers, "getProviders")
+      .resolves([null, [{ "provider-id": "TEST", "short-name": "TEST" }]]);
+
+    const { statusCode, body } = await request(app).get("/stac/ALL/collections/foo/items");
+
+    expect(statusCode).to.equal(404);
+    expect(body).to.deep.equal({
+      errors: ["This operation is not allowed for the ALL Catalog."],
+    });
+  });
+});
+
+describe("GET /ALL/collections/:collection/items/:item", () => {
+  it("should return a 404", async () => {
+    sandbox
+      .stub(Providers, "getProviders")
+      .resolves([null, [{ "provider-id": "TEST", "short-name": "TEST" }]]);
+
+    const { statusCode, body } = await request(app).get("/stac/ALL/collections/foo/items/bar");
+
+    expect(statusCode).to.equal(404);
+    expect(body).to.deep.equal({
+      errors: ["This operation is not allowed for the ALL Catalog."],
+    });
+  });
+});

--- a/src/__tests__/providerCatalog.spec.ts
+++ b/src/__tests__/providerCatalog.spec.ts
@@ -143,6 +143,7 @@ describe("GET /:provider", () => {
             items: mockCollections.map((coll) => ({
               id: `${coll.id}`,
               title: coll.title ?? faker.random.words(4),
+              provider: `TEST`
             })),
           });
 
@@ -179,6 +180,7 @@ describe("GET /:provider", () => {
           items: mockCollections.map((coll) => ({
             id: `${coll.id}`,
             title: coll.title ?? faker.random.words(4),
+            provider: 'TEST'
           })),
         });
 
@@ -209,6 +211,7 @@ describe("GET /:provider", () => {
           items: mockCollections.map((coll) => ({
             id: `${coll.id}`,
             title: coll.title ?? faker.random.words(4),
+            provider: `TEST`
           })),
         });
 
@@ -232,6 +235,7 @@ describe("GET /:provider", () => {
           items: mockCollections.map((coll) => ({
             id: `${coll.id}`,
             title: coll.title ?? faker.random.words(4),
+            provider: `TEST`
           })),
         });
 

--- a/src/__tests__/providerCatalog.spec.ts
+++ b/src/__tests__/providerCatalog.spec.ts
@@ -143,7 +143,7 @@ describe("GET /:provider", () => {
             items: mockCollections.map((coll) => ({
               id: `${coll.id}`,
               title: coll.title ?? faker.random.words(4),
-              provider: `TEST`
+              provider: `TEST`,
             })),
           });
 
@@ -211,8 +211,8 @@ describe("GET /:provider", () => {
           items: mockCollections.map((coll) => ({
             id: `${coll.id}`,
             title: coll.title ?? faker.random.words(4),
-            provider: "TEST`" 
-          })),        
+            provider: "TEST`",
+          })),
         });
 
         const { body: catalog } = await request(stacApp).get("/stac/TEST");
@@ -297,15 +297,17 @@ describe("GET /:provider", () => {
       sandbox
         .stub(Provider, "getProviders")
         .resolves([null, [{ "provider-id": "TEST", "short-name": "TEST" }]]);
-      
-      const getCollectionsSpy = sandbox.stub(Collections, "getCollectionIds").resolves({ count: 0, cursor: null, items: [] });
+
+      const getCollectionsSpy = sandbox
+        .stub(Collections, "getCollectionIds")
+        .resolves({ count: 0, cursor: null, items: [] });
 
       const res = await request(stacApp).get("/stac/ALL");
       expect(res.statusCode).to.equal(200);
-      // getCollectionIds should have no provider clause in query argument. 
-      // If this was any provider other than 'ALL', this method would be 
+      // getCollectionIds should have no provider clause in query argument.
+      // If this was any provider other than 'ALL', this method would be
       // called with { provider: 'TEST', cursor: undefined, limit: NaN }
-      expect(getCollectionsSpy).to.have.been.calledWith({cursor: undefined, limit: NaN})
+      expect(getCollectionsSpy).to.have.been.calledWith({ cursor: undefined, limit: NaN });
     });
     it("should return rel=child links whose href contains a provider rather than 'ALL'", async () => {
       sandbox
@@ -330,11 +332,11 @@ describe("GET /:provider", () => {
 
       mockCollections.forEach((collection) => {
         const childLink = children.find((l: Link) => l.href.endsWith(collection.id));
-    
+
         expect(childLink.href).to.endWith(`/TEST/collections/${collection.id}`);
         expect(childLink.href).to.not.contain("/ALL/");
       });
-      
+
       expect(statusCode).to.equal(200);
     });
     it("should not return any links of rel=search", async () => {

--- a/src/__tests__/providerCollection.spec.ts
+++ b/src/__tests__/providerCollection.spec.ts
@@ -474,15 +474,15 @@ describe("GET /:provider/collections/:collectionId", () => {
 
 describe("GET /ALL/collections", () => {
   describe("given the ALL catalog", () => {
-    it("returns collections from multiple providers", async () => {
+    it("returns item links relative to the provider catalogs rather than ALL", async () => {
       sandbox
         .stub(Providers, "getProviders")
         .resolves([null, [{ "provider-id": "TEST", "short-name": "TEST" }]]);
 
-      const mockCollections = generateSTACCollections(3);
+      const mockCollections = generateSTACCollections(1);
 
       sandbox.stub(Collections, "getCollections").resolves({
-        count: 3,
+        count: 1,
         cursor: null,
         items: mockCollections,
       });
@@ -490,27 +490,13 @@ describe("GET /ALL/collections", () => {
       const { statusCode, body } = await request(app).get("/stac/ALL/collections");
 
       expect(statusCode).to.equal(200);
-      expect(body.collections).to.have.lengthOf(3);
+      expect(body.collections).to.have.lengthOf(1);
       // Make sure that we are determining the 'provider' element of the items path from the provider detailed
       // in the collection metadata rather than the ALL route.
       expect(body.collections[0].links.find((l: Link) => l.rel === "items").href).to.include(
         "/PROV1/"
       );
       expect(body.collections[0].links.find((l: Link) => l.rel === "items").href).to.not.include(
-        "/ALL/"
-      );
-
-      expect(body.collections[1].links.find((l: Link) => l.rel === "items").href).to.include(
-        "/PROV1/"
-      );
-      expect(body.collections[1].links.find((l: Link) => l.rel === "items").href).to.not.include(
-        "/ALL/"
-      );
-
-      expect(body.collections[2].links.find((l: Link) => l.rel === "items").href).to.include(
-        "/PROV1/"
-      );
-      expect(body.collections[2].links.find((l: Link) => l.rel === "items").href).to.not.include(
         "/ALL/"
       );
     });
@@ -522,7 +508,7 @@ describe("GET /ALL/collections", () => {
       const mockCollections = generateSTACCollections(1);
 
       sandbox.stub(Collections, "getCollections").resolves({
-        count: 3,
+        count: 1,
         cursor: null,
         items: mockCollections,
       });

--- a/src/__tests__/providerCollection.spec.ts
+++ b/src/__tests__/providerCollection.spec.ts
@@ -134,6 +134,7 @@ describe("GET /:provider/collections", () => {
       // Expect the href to match the generic STAC API.
       const link1: Link = body.collections[1].links.find((l: Link) => l.rel === "items");
       expect(link1.href).to.contain("/stac/TEST/collections/");
+      expect(link1.href).to.endsWith("/items");
     });
   });
 
@@ -467,6 +468,87 @@ describe("GET /:provider/collections/:collectionId", () => {
       const stacSchemaValid = validate(body);
 
       expect(stacSchemaValid, JSON.stringify(validate.errors)).to.be.true;
+    });
+  });
+});
+
+describe("GET /ALL/collections", () => {
+  describe("given the ALL catalog", () => {
+    it("returns collections from multiple providers", async () => {
+      sandbox
+        .stub(Providers, "getProviders")
+        .resolves([null, [{ "provider-id": "TEST", "short-name": "TEST" }]]);
+
+      const mockCollections = generateSTACCollections(3);
+
+      sandbox.stub(Collections, "getCollections").resolves({
+        count: 3,
+        cursor: null,
+        items: mockCollections,
+      });
+
+      const { statusCode, body } = await request(app).get("/stac/ALL/collections");
+
+      expect(statusCode).to.equal(200);
+      expect(body.collections).to.have.lengthOf(3);
+      // Make sure that we are determining the 'provider' element of the items path from the provider detailed
+      // in the collection metadata rather than the ALL route.
+      expect(body.collections[0].links.find((l: Link) => l.rel === "items").href).to.include(
+        "/PROV1/"
+      );
+      expect(body.collections[0].links.find((l: Link) => l.rel === "items").href).to.not.include(
+        "/ALL/"
+      );
+
+      expect(body.collections[1].links.find((l: Link) => l.rel === "items").href).to.include(
+        "/PROV1/"
+      );
+      expect(body.collections[1].links.find((l: Link) => l.rel === "items").href).to.not.include(
+        "/ALL/"
+      );
+
+      expect(body.collections[2].links.find((l: Link) => l.rel === "items").href).to.include(
+        "/PROV1/"
+      );
+      expect(body.collections[2].links.find((l: Link) => l.rel === "items").href).to.not.include(
+        "/ALL/"
+      );
+    });
+    it("returns collection items links that end in 'items", async () => {
+      sandbox
+        .stub(Providers, "getProviders")
+        .resolves([null, [{ "provider-id": "TEST", "short-name": "TEST" }]]);
+
+      const mockCollections = generateSTACCollections(1);
+
+      sandbox.stub(Collections, "getCollections").resolves({
+        count: 3,
+        cursor: null,
+        items: mockCollections,
+      });
+
+      const { statusCode, body } = await request(app).get("/stac/ALL/collections");
+
+      expect(statusCode).to.equal(200);
+      expect(body.collections).to.have.lengthOf(1);
+      expect(body.collections[0].links.find((l: Link) => l.rel === "items").href).to.endsWith(
+        "/items"
+      );
+    });
+  });
+});
+
+describe("GET /ALL/collections/:collectionId", () => {
+  it("should return a 404", async () => {
+    sandbox
+      .stub(Providers, "getProviders")
+      .resolves([null, [{ "provider-id": "TEST", "short-name": "TEST" }]]);
+
+    const { statusCode, body } = await request(app).get("/stac/ALL/collections/foo");
+
+    expect(statusCode).to.equal(404);
+    expect(body).to.deep.equal({
+      errors: ["This operation is not allowed for the ALL Catalog."],
     });
   });
 });

--- a/src/__tests__/providerSearch.spec.ts
+++ b/src/__tests__/providerSearch.spec.ts
@@ -305,3 +305,37 @@ describe("Query validation", () => {
     });
   });
 });
+
+describe("GET /ALL/search", () => {
+  describe("given an 'ALL' provider", () => {
+    it("should return a 404", async () => {
+      sandbox
+      .stub(Providers, "getProviders")
+      .resolves([null, [{ "provider-id": "TEST", "short-name": "TEST" }]]);
+
+      const { statusCode, body } = await request(app).get("/stac/ALL/search");
+
+      expect(statusCode).to.equal(404);
+      expect(body).to.deep.equal({
+        errors: ["This operation is not allowed for the ALL Catalog."],
+      });
+    });
+  });
+});
+
+describe("POST /ALL/search", () => {
+  describe("given an 'ALL' provider", () => {
+    it("should return a 404", async () => {
+      sandbox
+      .stub(Providers, "getProviders")
+      .resolves([null, [{ "provider-id": "TEST", "short-name": "TEST" }]]);
+
+      const { statusCode, body } = await request(app).post("/stac/ALL/search");
+
+      expect(statusCode).to.equal(404);
+      expect(body).to.deep.equal({
+        errors: ["This operation is not allowed for the ALL Catalog."],
+      });
+    });
+  });
+});

--- a/src/__tests__/providerSearch.spec.ts
+++ b/src/__tests__/providerSearch.spec.ts
@@ -310,8 +310,8 @@ describe("GET /ALL/search", () => {
   describe("given an 'ALL' provider", () => {
     it("should return a 404", async () => {
       sandbox
-      .stub(Providers, "getProviders")
-      .resolves([null, [{ "provider-id": "TEST", "short-name": "TEST" }]]);
+        .stub(Providers, "getProviders")
+        .resolves([null, [{ "provider-id": "TEST", "short-name": "TEST" }]]);
 
       const { statusCode, body } = await request(app).get("/stac/ALL/search");
 
@@ -327,8 +327,8 @@ describe("POST /ALL/search", () => {
   describe("given an 'ALL' provider", () => {
     it("should return a 404", async () => {
       sandbox
-      .stub(Providers, "getProviders")
-      .resolves([null, [{ "provider-id": "TEST", "short-name": "TEST" }]]);
+        .stub(Providers, "getProviders")
+        .resolves([null, [{ "provider-id": "TEST", "short-name": "TEST" }]]);
 
       const { statusCode, body } = await request(app).post("/stac/ALL/search");
 

--- a/src/__tests__/rootCatalog.spec.ts
+++ b/src/__tests__/rootCatalog.spec.ts
@@ -99,8 +99,7 @@ describe("GET /stac", () => {
 
       expect(statusCode).to.equal(200);
       const [, expectedProviders] = cmrProvidersResponse;
-      console.debug(`Body: ${JSON.stringify(body)}`)
-      // Find the all catalog links.find((link) => link.rel === "items");
+      
       const allLink = body.links.find((l: Link) => l.title === "all");
 
       expect(allLink.href).to.match(/^(http)s?:\/\/.*\w+/);

--- a/src/__tests__/rootCatalog.spec.ts
+++ b/src/__tests__/rootCatalog.spec.ts
@@ -93,6 +93,23 @@ describe("GET /stac", () => {
         expect(providerLink.title).to.equal(provider["provider-id"]);
       });
     });
+
+    it("should have an entry for the 'ALL' catalog", async () => {
+      const { statusCode, body } = await request(app).get("/stac");
+
+      expect(statusCode).to.equal(200);
+      const [, expectedProviders] = cmrProvidersResponse;
+      console.debug(`Body: ${JSON.stringify(body)}`)
+      // Find the all catalog links.find((link) => link.rel === "items");
+      const allLink = body.links.find((l: Link) => l.title === "all");
+
+      expect(allLink.href).to.match(/^(http)s?:\/\/.*\w+/);
+      expect(allLink.href).to.endWith('/stac/ALL');
+      expect(allLink.href).to.not.contain("?param=value");
+      expect(allLink.rel).to.equal("child");
+      expect(allLink.type).to.equal("application/json");
+      expect(allLink.title).to.equal("all");
+    });
   });
 
   describe("given CMR providers endpoint responds with an error", () => {
@@ -147,6 +164,6 @@ describe("/cloudstac", () => {
 
     expect(body.links.find((l: { title: string }) => l.title === "NOT_CLOUD")).to.be.undefined;
 
-    expect(mockCmrHits).to.have.been.calledTwice;
+    expect(mockCmrHits).to.have.been.calledThrice;
   });
 });

--- a/src/__tests__/rootCatalog.spec.ts
+++ b/src/__tests__/rootCatalog.spec.ts
@@ -99,11 +99,11 @@ describe("GET /stac", () => {
 
       expect(statusCode).to.equal(200);
       const [, expectedProviders] = cmrProvidersResponse;
-      
+
       const allLink = body.links.find((l: Link) => l.title === "all");
 
       expect(allLink.href).to.match(/^(http)s?:\/\/.*\w+/);
-      expect(allLink.href).to.endWith('/stac/ALL');
+      expect(allLink.href).to.endWith("/stac/ALL");
       expect(allLink.href).to.not.contain("?param=value");
       expect(allLink.rel).to.equal("child");
       expect(allLink.type).to.equal("application/json");

--- a/src/domains/collections.ts
+++ b/src/domains/collections.ts
@@ -342,7 +342,11 @@ export const getCollectionIds = async (
     count,
     items: collectionIds,
   } = await paginateQuery(collectionIdsQuery, params, opts, collectionIdsHandler);
-  return { cursor, count, items: collectionIds as { id: string; title: string; provider: string }[] };
+  return {
+    cursor,
+    count,
+    items: collectionIds as { id: string; title: string; provider: string }[],
+  };
 };
 
 /**

--- a/src/domains/collections.ts
+++ b/src/domains/collections.ts
@@ -57,6 +57,7 @@ const collectionIdsQuery = gql`
         conceptId
         entryId
         title
+        provider
       }
     }
   }
@@ -242,7 +243,7 @@ export const collectionToStac = (collection: Collection): STACCollection => {
   const extent = createExtent(collection);
   const keywords = createKeywords(collection);
   const links = generateCollectionLinks(collection, [licenseLink]);
-  const provider = generateProviders(collection);
+  const providers = generateProviders(collection);
   const summaries = createSummaries(collection);
 
   return {
@@ -253,7 +254,7 @@ export const collectionToStac = (collection: Collection): STACCollection => {
     stac_version: STAC_VERSION,
     extent,
     assets,
-    provider,
+    providers,
     links,
     license,
     keywords,
@@ -334,14 +335,14 @@ export const getCollectionIds = async (
 ): Promise<{
   count: number;
   cursor: string | null;
-  items: { id: string; title: string }[];
+  items: { id: string; title: string; provider: string }[];
 }> => {
   const {
     cursor,
     count,
     items: collectionIds,
   } = await paginateQuery(collectionIdsQuery, params, opts, collectionIdsHandler);
-  return { cursor, count, items: collectionIds as { id: string; title: string }[] };
+  return { cursor, count, items: collectionIds as { id: string; title: string; provider: string }[] };
 };
 
 /**
@@ -356,7 +357,7 @@ export const getAllCollectionIds = async (
 ): Promise<{
   count: number;
   cursor: string | null;
-  items: { id: string; title: string }[];
+  items: { id: string; title: string; provider: string }[];
 }> => {
   params.limit = CMR_QUERY_MAX;
 

--- a/src/domains/providers.ts
+++ b/src/domains/providers.ts
@@ -37,8 +37,8 @@ export const conformance = [
  */
 export const getProviders = async (): Promise<[string, null] | [null, Provider[]]> => {
   try {
+    console.debug(`GET ${CMR_LB_INGEST}/providers`);
     const { data: providers } = await axios.get(`${CMR_LB_INGEST}/providers`);
-    providers.push(ALL_PROVIDERS);
     return [null, providers];
   } catch (err) {
     console.error("A problem occurred fetching providers", err);
@@ -57,7 +57,7 @@ export const getProvider = async (
   if (errs) {
     return [errs as string, null];
   }
-
+  providers?.push(ALL_PROVIDERS);
   return [
     null,
     (providers ?? []).find((provider) => provider["provider-id"] === providerId) ?? null,
@@ -86,6 +86,7 @@ export const getCloudProviders = async (
   await Promise.all(
     (candidates ?? []).map(async (provider) => {
       try {
+        console.debug(`GET ${CMR_LB_SEARCH_COLLECTIONS}`);
         const { headers } = await axios.get(CMR_LB_SEARCH_COLLECTIONS, {
           headers: mergeMaybe({}, { authorization }),
           params: { provider: provider["short-name"], cloud_hosted: true },

--- a/src/domains/providers.ts
+++ b/src/domains/providers.ts
@@ -8,10 +8,10 @@ const CMR_LB_INGEST = `${CMR_LB_URL}/ingest`;
 const CMR_LB_SEARCH = `${CMR_LB_URL}/search`;
 const CMR_LB_SEARCH_COLLECTIONS = `${CMR_LB_SEARCH}/collections`;
 
-export const ALL_PROVIDER = "ALL"
+export const ALL_PROVIDER = "ALL";
 export const ALL_PROVIDERS = {
   "provider-id": ALL_PROVIDER.toUpperCase(),
-  "short-name": ALL_PROVIDER.toLowerCase()
+  "short-name": ALL_PROVIDER.toLowerCase(),
 };
 
 export const conformance = [

--- a/src/domains/providers.ts
+++ b/src/domains/providers.ts
@@ -8,6 +8,12 @@ const CMR_LB_INGEST = `${CMR_LB_URL}/ingest`;
 const CMR_LB_SEARCH = `${CMR_LB_URL}/search`;
 const CMR_LB_SEARCH_COLLECTIONS = `${CMR_LB_SEARCH}/collections`;
 
+export const ALL_PROVIDER = "ALL"
+export const ALL_PROVIDERS = {
+  "provider-id": ALL_PROVIDER.toUpperCase(),
+  "short-name": ALL_PROVIDER.toLowerCase()
+};
+
 export const conformance = [
   "https://api.stacspec.org/v1.0.0-rc.2/core",
   "https://api.stacspec.org/v1.0.0-rc.2/item-search",
@@ -32,6 +38,7 @@ export const conformance = [
 export const getProviders = async (): Promise<[string, null] | [null, Provider[]]> => {
   try {
     const { data: providers } = await axios.get(`${CMR_LB_INGEST}/providers`);
+    providers.push(ALL_PROVIDERS);
     return [null, providers];
   } catch (err) {
     console.error("A problem occurred fetching providers", err);

--- a/src/domains/stac.ts
+++ b/src/domains/stac.ts
@@ -587,7 +587,8 @@ export const paginateQuery = async (
     if (errors) throw new Error(errors);
     if (!data) throw new Error("No data returned from GraphQL during paginated query");
     const { count, cursor, items } = data;
-
+    console.debug("paginateQuery");
+    console.debug(JSON.stringify(data));
     return { items: items, count, cursor };
   } catch (err: unknown) {
     if (

--- a/src/domains/stac.ts
+++ b/src/domains/stac.ts
@@ -580,6 +580,7 @@ export const paginateQuery = async (
 
   try {
     console.info(timingMessage);
+    console.debug(`GET ${GRAPHQL_URL}`);
     const response = await request(GRAPHQL_URL, gqlQuery, variables, requestHeaders);
     // use the passed in results handler
     const [errors, data] = handler(response);
@@ -587,8 +588,6 @@ export const paginateQuery = async (
     if (errors) throw new Error(errors);
     if (!data) throw new Error("No data returned from GraphQL during paginated query");
     const { count, cursor, items } = data;
-    console.debug("paginateQuery");
-    console.debug(JSON.stringify(data));
     return { items: items, count, cursor };
   } catch (err: unknown) {
     if (

--- a/src/middleware/index.ts
+++ b/src/middleware/index.ts
@@ -11,7 +11,7 @@ import {
 import { WarmProviderCache } from "../domains/cache";
 import { getCollections } from "../domains/collections";
 import { parseOrdinateString } from "../domains/bounding-box";
-import { ALL_PROVIDER, getProviders, getCloudProviders } from "../domains/providers";
+import { ALL_PROVIDER, getProviders, getCloudProviders, ALL_PROVIDERS } from "../domains/providers";
 
 import { scrubTokens, mergeMaybe, ERRORS } from "../utils";
 import { validDateTime } from "../utils/datetime";
@@ -94,7 +94,8 @@ export const refreshProviderCache = async (req: Request, _res: Response, next: N
     if (errs || !updatedProviders) {
       return next(new ServiceUnavailableError(ERRORS.serviceUnavailable));
     }
-
+    updatedProviders
+    updatedProviders.push(ALL_PROVIDERS);
     updatedProviders.forEach((provider) => {
       cachedProviders.set(provider["provider-id"], provider);
     });

--- a/src/middleware/index.ts
+++ b/src/middleware/index.ts
@@ -150,23 +150,27 @@ export const validateProvider = async (req: Request, _res: Response, next: NextF
 };
 
 /**
- * Middleware validates the catalog in a search route is not 'ALL'.
+ * Middleware validates the provider in the route is not ALL.
+ *  
+ * This validation is only required for routes that will search CMR based on the provider
+ * supplied.
  *
- * If the provider is not 'ALL', the validation succeeds.
+ * If the provider is not 'ALL' then validation passes.
  * If the provider is 'ALL', it exits early with a 404.
+
  */
-export const validateCatalogForSearch = async (req: Request, _res: Response, next: NextFunction) => {
-  console.debug('validateCatalogForSearch');
+export const validateNotAllProvider = async (req: Request, _res: Response, next: NextFunction) => {
   
   const { providerId } = req.params;
 
   if (providerId == ALL_PROVIDER.toString()) {
     next(
       new ItemNotFound(
-        `The ALL catalog does not support item searches.`
+        `This operation is not allowed for the ${ALL_PROVIDER.toString()} Catalog.`
       )
     );
-  } else {
+  }
+  else {
     next();
   }
 };

--- a/src/middleware/index.ts
+++ b/src/middleware/index.ts
@@ -94,7 +94,7 @@ export const refreshProviderCache = async (req: Request, _res: Response, next: N
     if (errs || !updatedProviders) {
       return next(new ServiceUnavailableError(ERRORS.serviceUnavailable));
     }
-    updatedProviders
+    updatedProviders;
     updatedProviders.push(ALL_PROVIDERS);
     updatedProviders.forEach((provider) => {
       cachedProviders.set(provider["provider-id"], provider);
@@ -140,7 +140,7 @@ export const validateProvider = async (req: Request, _res: Response, next: NextF
         `Provider [${providerId}] not found or does not have any visible cloud hosted collections.`
       )
     );
-  // If it's not the 'ALL' provider and the provider ID cannot be found then throw an error
+    // If it's not the 'ALL' provider and the provider ID cannot be found then throw an error
   } else if (!provider && providerId != ALL_PROVIDER.toString()) {
     next(new ItemNotFound(`Provider [${providerId}] not found.`));
   } else {
@@ -160,17 +160,13 @@ export const validateProvider = async (req: Request, _res: Response, next: NextF
 
  */
 export const validateNotAllProvider = async (req: Request, _res: Response, next: NextFunction) => {
-  
   const { providerId } = req.params;
 
   if (providerId == ALL_PROVIDER.toString()) {
     next(
-      new ItemNotFound(
-        `This operation is not allowed for the ${ALL_PROVIDER.toString()} Catalog.`
-      )
+      new ItemNotFound(`This operation is not allowed for the ${ALL_PROVIDER.toString()} Catalog.`)
     );
-  }
-  else {
+  } else {
     next();
   }
 };

--- a/src/routes/__tests__/browse.spec.ts
+++ b/src/routes/__tests__/browse.spec.ts
@@ -7,7 +7,13 @@ chai.use(sinonChai);
 const { expect } = chai;
 
 import * as gql from "graphql-request";
-import { collectionHandler, collectionsHandler, addItemLinkIfNotPresent, generateBaseUrlForCollection, generateCollectionResponse } from "../browse";
+import {
+  collectionHandler,
+  collectionsHandler,
+  addItemLinkIfNotPresent,
+  generateBaseUrlForCollection,
+  generateCollectionResponse,
+} from "../browse";
 import { generateSTACCollections } from "../../utils/testUtils";
 
 describe("addItemLinkIfNotPresent", () => {
@@ -86,28 +92,34 @@ describe("generateBaseUrlForCollection", () => {
   it("will use the provider name for an ALL collection result", async () => {
     let stacCollection = generateSTACCollections(1)[0];
 
-    const baseUrl = generateBaseUrlForCollection('http://localhost:3000/stac/ALL/collections/Test%201_1.2', stacCollection);
-    expect(baseUrl).to.equal('http://localhost:3000/stac/PROV1/collections/Test%201_1.2');
+    const baseUrl = generateBaseUrlForCollection(
+      "http://localhost:3000/stac/ALL/collections/Test%201_1.2",
+      stacCollection
+    );
+    expect(baseUrl).to.equal("http://localhost:3000/stac/PROV1/collections/Test%201_1.2");
   });
   it("will use the same provider name for any other collection result", async () => {
     let stacCollection = generateSTACCollections(1)[0];
 
-    const baseUrl = generateBaseUrlForCollection('http://localhost:3000/stac/PROV1/collections/Test%201_1.2', stacCollection);
-    expect(baseUrl).to.equal('http://localhost:3000/stac/PROV1/collections/Test%201_1.2');
+    const baseUrl = generateBaseUrlForCollection(
+      "http://localhost:3000/stac/PROV1/collections/Test%201_1.2",
+      stacCollection
+    );
+    expect(baseUrl).to.equal("http://localhost:3000/stac/PROV1/collections/Test%201_1.2");
   });
 });
 
 describe("generateCollectionResponse", () => {
   it("will add the correct description if the provider is 'ALL'", async () => {
     let stacCollections = generateSTACCollections(1);
-    const baseUrl = 'http://localhost:3000/stac/ALL/collections'
+    const baseUrl = "http://localhost:3000/stac/ALL/collections";
     const collectionsResponse = generateCollectionResponse(baseUrl, [], stacCollections);
-    expect(collectionsResponse.description).to.equal('All collections provided by CMR');
+    expect(collectionsResponse.description).to.equal("All collections provided by CMR");
   });
   it("will add the correct description if the provider is a real provider", async () => {
     let stacCollections = generateSTACCollections(1);
-    const baseUrl = 'http://localhost:3000/stac/PROV1/collections'
+    const baseUrl = "http://localhost:3000/stac/PROV1/collections";
     const collectionsResponse = generateCollectionResponse(baseUrl, [], stacCollections);
-    expect(collectionsResponse.description).to.equal('All collections provided by PROV1');
-  });  
+    expect(collectionsResponse.description).to.equal("All collections provided by PROV1");
+  });
 });

--- a/src/routes/__tests__/browse.spec.ts
+++ b/src/routes/__tests__/browse.spec.ts
@@ -7,10 +7,10 @@ chai.use(sinonChai);
 const { expect } = chai;
 
 import * as gql from "graphql-request";
-import { collectionHandler, collectionsHandler, addItemLinkIfPresent } from "../browse";
+import { collectionHandler, collectionsHandler, addItemLinkIfNotPresent, generateBaseUrlForCollection, generateCollectionResponse } from "../browse";
 import { generateSTACCollections } from "../../utils/testUtils";
 
-describe("addItemLinkIfPresent", () => {
+describe("addItemLinkIfNotPresent", () => {
   it("will add an item link if no item link is present", async () => {
     // Create a STACCollection with no item link
     let stacCollection = generateSTACCollections(1)[0];
@@ -24,7 +24,7 @@ describe("addItemLinkIfPresent", () => {
 
     const numberoOfLinks = stacCollection.links.length;
     // Invoke method
-    addItemLinkIfPresent(stacCollection, "https://foo.com");
+    addItemLinkIfNotPresent(stacCollection, "https://foo.com");
     // Observe an addiitonal link in the STAC Collection with rel=items etc.
     expect(stacCollection.links.length).to.equal(numberoOfLinks + 1);
     expect(stacCollection).to.have.deep.property("links", [
@@ -62,7 +62,7 @@ describe("addItemLinkIfPresent", () => {
     });
     const numberoOfLinks = stacCollection.links.length;
     // Invoke method
-    addItemLinkIfPresent(stacCollection, "https://foo.com/items");
+    addItemLinkIfNotPresent(stacCollection, "https://foo.com/items");
     // Observe no addiitonal link in the STAC Collection and that the item link remains a CMR link
     expect(stacCollection.links.length).to.equal(numberoOfLinks);
     expect(stacCollection).to.have.deep.property("links", [
@@ -80,4 +80,34 @@ describe("addItemLinkIfPresent", () => {
       },
     ]);
   });
+});
+
+describe("generateBaseUrlForCollection", () => {
+  it("will use the provider name for an ALL collection result", async () => {
+    let stacCollection = generateSTACCollections(1)[0];
+
+    const baseUrl = generateBaseUrlForCollection('http://localhost:3000/stac/ALL/collections/Test%201_1.2', stacCollection);
+    expect(baseUrl).to.equal('http://localhost:3000/stac/PROV1/collections/Test%201_1.2');
+  });
+  it("will use the same provider name for any other collection result", async () => {
+    let stacCollection = generateSTACCollections(1)[0];
+
+    const baseUrl = generateBaseUrlForCollection('http://localhost:3000/stac/PROV1/collections/Test%201_1.2', stacCollection);
+    expect(baseUrl).to.equal('http://localhost:3000/stac/PROV1/collections/Test%201_1.2');
+  });
+});
+
+describe("generateCollectionResponse", () => {
+  it("will add the correct description if the provider is 'ALL'", async () => {
+    let stacCollections = generateSTACCollections(1);
+    const baseUrl = 'http://localhost:3000/stac/ALL/collections'
+    const collectionsResponse = generateCollectionResponse(baseUrl, [], stacCollections);
+    expect(collectionsResponse.description).to.equal('All collections provided by CMR');
+  });
+  it("will add the correct description if the provider is a real provider", async () => {
+    let stacCollections = generateSTACCollections(1);
+    const baseUrl = 'http://localhost:3000/stac/PROV1/collections'
+    const collectionsResponse = generateCollectionResponse(baseUrl, [], stacCollections);
+    expect(collectionsResponse.description).to.equal('All collections provided by PROV1');
+  });  
 });

--- a/src/routes/browse.ts
+++ b/src/routes/browse.ts
@@ -7,6 +7,7 @@ import { buildQuery, stringifyQuery } from "../domains/stac";
 import { ItemNotFound } from "../models/errors";
 import { getBaseUrl, mergeMaybe, stacContext } from "../utils";
 import { STACCollection } from "../@types/StacCollection";
+import { ALL_PROVIDER } from "../domains/providers"
 
 const collectionLinks = (req: Request, nextCursor?: string | null): Links => {
   const { stacRoot, self } = stacContext(req);
@@ -52,6 +53,12 @@ export const collectionsHandler = async (req: Request, res: Response): Promise<v
 
   const query = await buildQuery(req);
 
+  // If the query contains a "provider": "ALL" clause, we need to remove it as
+  // this is a 'special' provider that means 'all providers'. The absence
+  // of a provider clause gives the right query.
+  if ("provider" in query && query.provider == ALL_PROVIDER)
+    delete query.provider;
+
   const { cursor, items: collections } = await getCollections(query, {
     headers,
   });
@@ -59,9 +66,10 @@ export const collectionsHandler = async (req: Request, res: Response): Promise<v
   const { stacRoot, self } = stacContext(req);
 
   collections.forEach((collection) => {
+    const baseUrl = generateBaseUrlForCollection(getBaseUrl(self), collection);
     collection.links.push({
       rel: "self",
-      href: `${getBaseUrl(self)}/${encodeURIComponent(collection.id)}`,
+      href: `${baseUrl}/${encodeURIComponent(collection.id)}`,
       type: "application/json",
     });
     collection.links.push({
@@ -69,16 +77,12 @@ export const collectionsHandler = async (req: Request, res: Response): Promise<v
       href: encodeURI(stacRoot),
       type: "application/json",
     });
-    addItemLinkIfPresent(collection, `${getBaseUrl(self)}/${encodeURIComponent(collection.id)}`);
+    addItemLinkIfNotPresent(collection, `${baseUrl}/${encodeURIComponent(collection.id)}`);
   });
 
   const links = collectionLinks(req, cursor);
 
-  const collectionsResponse = {
-    description: `All collections provided by ${self.split("/").at(-2)}`,
-    links,
-    collections,
-  };
+  const collectionsResponse = generateCollectionResponse(self, links, collections);
 
   res.json(collectionsResponse);
 };
@@ -102,9 +106,50 @@ export const collectionHandler = async (req: Request, res: Response): Promise<vo
     ? [...collectionLinks(req), ...(collection.links ?? [])]
     : [...collectionLinks(req)];
   const { path } = stacContext(req);
-  addItemLinkIfPresent(collection, path);
+  addItemLinkIfNotPresent(collection, path);
   res.json(collection);
 };
+
+/**
+ * Marshall the description, links and collections into a valid response
+ * This catalog may be 'ALL'. If so, we need to override the description
+ * property to convey that this results represents all of CMR
+ * 
+ * @param self the base url
+ * @param links the urls associated with this response
+ * @param collections the STAC collection object that contains the provider of the collection
+ * 
+ */
+
+export function generateCollectionResponse(self: string, links: Links, collections: STACCollection[]): { description: string; links: Links; collections: STACCollection[]; } {
+  // Special case. If provider is 'ALL' use descirpion of 'provided by CMR'
+  let provider = self.split("/").at(-2)
+  if (provider == ALL_PROVIDER)
+    provider = "CMR";
+
+  const collectionsResponse = {
+    description: `All collections provided by ${provider}`,
+    links,
+    collections,
+  };
+  return collectionsResponse;
+}
+
+/**
+ * This catalog may be 'ALL' but the link to the collection's items must reference
+ * the catalog associated with the collection's provider
+ * 
+ * @param self the context of the STAC urls
+ * @param collection the STAC collection object that contains the provider of the collection
+ */
+
+export function generateBaseUrlForCollection(baseUrl: string, collection: STACCollection): string {
+  // Extract the actual provider of the collection
+  const provider = collection.providers.find((p) => p.roles?.includes("producer"));
+  // Construct the items url from that provider
+  if (provider) baseUrl = baseUrl.replace("/ALL/", `/${provider.name}/`);
+  return baseUrl;
+}
 
 /**
  * A CMR collection can now indicate to consumers that it has a STAC API.
@@ -118,7 +163,8 @@ export const collectionHandler = async (req: Request, res: Response): Promise<vo
  *  @param url the generic link to a CMR STAC API
  */
 
-export function addItemLinkIfPresent(collection: STACCollection, url: string) {
+export function addItemLinkIfNotPresent(collection: STACCollection, url: string) {
+  
   const itemsLink = collection.links.find((link) => link.rel === "items");
 
   if (!itemsLink) {

--- a/src/routes/browse.ts
+++ b/src/routes/browse.ts
@@ -8,7 +8,7 @@ import { buildQuery } from "../domains/stac";
 import { ItemNotFound } from "../models/errors";
 import { getBaseUrl, mergeMaybe, stacContext } from "../utils";
 import { STACCollection } from "../@types/StacCollection";
-import { ALL_PROVIDER } from "../domains/providers"
+import { ALL_PROVIDER } from "../domains/providers";
 
 const collectionLinks = (req: Request, nextCursor?: string | null): Links => {
   const { stacRoot, self } = stacContext(req);
@@ -57,8 +57,7 @@ export const collectionsHandler = async (req: Request, res: Response): Promise<v
   // If the query contains a "provider": "ALL" clause, we need to remove it as
   // this is a 'special' provider that means 'all providers'. The absence
   // of a provider clause gives the right query.
-  if ("provider" in query && query.provider == ALL_PROVIDER)
-    delete query.provider;
+  if ("provider" in query && query.provider == ALL_PROVIDER) delete query.provider;
 
   const { cursor, items: collections } = await getCollections(query, {
     headers,
@@ -115,18 +114,21 @@ export const collectionHandler = async (req: Request, res: Response): Promise<vo
  * Marshall the description, links and collections into a valid response
  * This catalog may be 'ALL'. If so, we need to override the description
  * property to convey that this results represents all of CMR
- * 
+ *
  * @param self the base url
  * @param links the urls associated with this response
  * @param collections the STAC collection object that contains the provider of the collection
- * 
+ *
  */
 
-export function generateCollectionResponse(self: string, links: Links, collections: STACCollection[]): { description: string; links: Links; collections: STACCollection[]; } {
+export function generateCollectionResponse(
+  self: string,
+  links: Links,
+  collections: STACCollection[]
+): { description: string; links: Links; collections: STACCollection[] } {
   // Special case. If provider is 'ALL' use descirpion of 'provided by CMR'
-  let provider = self.split("/").at(-2)
-  if (provider == ALL_PROVIDER)
-    provider = "CMR";
+  let provider = self.split("/").at(-2);
+  if (provider == ALL_PROVIDER) provider = "CMR";
 
   const collectionsResponse = {
     description: `All collections provided by ${provider}`,
@@ -139,7 +141,7 @@ export function generateCollectionResponse(self: string, links: Links, collectio
 /**
  * This catalog may be 'ALL' but the link to the collection's items must reference
  * the catalog associated with the collection's provider
- * 
+ *
  * @param self the context of the STAC urls
  * @param collection the STAC collection object that contains the provider of the collection
  */
@@ -165,7 +167,6 @@ export function generateBaseUrlForCollection(baseUrl: string, collection: STACCo
  */
 
 export function addItemLinkIfNotPresent(collection: STACCollection, url: string) {
-  
   const itemsLink = collection.links.find((link) => link.rel === "items");
 
   if (!itemsLink) {

--- a/src/routes/browse.ts
+++ b/src/routes/browse.ts
@@ -126,7 +126,7 @@ export function generateCollectionResponse(
   links: Links,
   collections: STACCollection[]
 ): { description: string; links: Links; collections: STACCollection[] } {
-  // Special case. If provider is 'ALL' use descirpion of 'provided by CMR'
+  // Special case. If provider is 'ALL' use description of 'provided by CMR'
   let provider = self.split("/").at(-2);
   if (provider == ALL_PROVIDER) provider = "CMR";
 

--- a/src/routes/catalog.ts
+++ b/src/routes/catalog.ts
@@ -7,7 +7,7 @@ import { getAllCollectionIds } from "../domains/collections";
 import { conformance } from "../domains/providers";
 import { ServiceUnavailableError } from "../models/errors";
 import { getBaseUrl, mergeMaybe, stacContext } from "../utils";
-import { CMR_QUERY_MAX, stringifyQuery } from "../domains/stac";
+import { CMR_QUERY_MAX } from "../domains/stac";
 import { ALL_PROVIDER } from "../domains/providers";
 
 const STAC_VERSION = process.env.STAC_VERSION ?? "1.0.0";

--- a/src/routes/catalog.ts
+++ b/src/routes/catalog.ts
@@ -144,7 +144,9 @@ export const providerCatalogHandler = async (req: Request, res: Response) => {
 
   const childLinks = (collections ?? []).map(({ id, title, provider }) => ({
     rel: "child",
-    href: `${getBaseUrl(self).concat("/").replace("/ALL/", "/" + provider + "/")}collections/${encodeURIComponent(id)}`,
+    href: `${getBaseUrl(self)
+      .concat("/")
+      .replace("/ALL/", "/" + provider + "/")}collections/${encodeURIComponent(id)}`,
     title,
     type: "application/json",
   }));

--- a/src/routes/catalog.ts
+++ b/src/routes/catalog.ts
@@ -81,7 +81,7 @@ const generateSelfLinks = (req: Request, nextCursor?: string | null, count?: num
   }
 
   const originalQuery = mergeMaybe(req.query, req.body);
-  
+
   // Add a 'next' link if there are more results available
   // This is determined by:
   //  1. The presence of a nextCursor (indicating more results)
@@ -103,8 +103,9 @@ const generateSelfLinks = (req: Request, nextCursor?: string | null, count?: num
 
 const providerCollections = async (
   req: Request
-): Promise<[null, { id: string; title: string; provider: string }[], string | null] | [string, null]> => {
-  
+): Promise<
+  [null, { id: string; title: string; provider: string }[], string | null] | [string, null]
+> => {
   const { headers, provider, query } = req;
 
   const cloudOnly = headers["cloud-stac"] === "true" ? { cloudHosted: true } : {};

--- a/src/routes/catalog.ts
+++ b/src/routes/catalog.ts
@@ -144,7 +144,7 @@ export const providerCatalogHandler = async (req: Request, res: Response) => {
 
   const childLinks = (collections ?? []).map(({ id, title, provider }) => ({
     rel: "child",
-    href: `${getBaseUrl(self).replace("ALL", provider)}/collections/${encodeURIComponent(id)}`,
+    href: `${getBaseUrl(self).concat("/").replace("/ALL/", "/" + provider + "/")}collections/${encodeURIComponent(id)}`,
     title,
     type: "application/json",
   }));

--- a/src/routes/catalog.ts
+++ b/src/routes/catalog.ts
@@ -103,6 +103,7 @@ const generateSelfLinks = (req: Request, nextCursor?: string | null, count?: num
 const providerCollections = async (
   req: Request
 ): Promise<[null, { id: string; title: string; provider: string }[], string | null] | [string, null]> => {
+  
   const { headers, provider, query } = req;
 
   const cloudOnly = headers["cloud-stac"] === "true" ? { cloudHosted: true } : {};

--- a/src/routes/catalog.ts
+++ b/src/routes/catalog.ts
@@ -127,9 +127,7 @@ const providerCollections = async (
 };
 
 export const providerCatalogHandler = async (req: Request, res: Response) => {
-  console.debug("providerCatalogHandler");
   const { provider } = req;
-  console.debug(provider);
 
   if (!provider) throw new ServiceUnavailableError("Could not retrieve provider information");
 

--- a/src/routes/healthcheck.ts
+++ b/src/routes/healthcheck.ts
@@ -6,7 +6,9 @@ const CMR_INGEST_HEALTH = `${CMR_LB_URL}/ingest/health`;
 const CMR_SEARCH_HEALTH = `${CMR_LB_URL}/search/health`;
 
 export const healthcheckHandler = async (_req: Request, res: Response) => {
+  console.debug(`GET ${CMR_INGEST_HEALTH}`);
   const { status: ingestStatus } = await axios.get(CMR_INGEST_HEALTH);
+  console.debug(`GET ${CMR_SEARCH_HEALTH}`);
   const { status: searchStatus } = await axios.get(CMR_SEARCH_HEALTH);
 
   if ([ingestStatus, searchStatus].every((status) => status === 200)) {

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -44,8 +44,20 @@ router.get(
 
 router
   .route("/:providerId/search")
-  .get(refreshProviderCache, validateNotAllProvider, validateProvider, validateStacQuery, wrapErrorHandler(searchHandler))
-  .post(refreshProviderCache, validateNotAllProvider, validateProvider, validateStacQuery, wrapErrorHandler(searchHandler));
+  .get(
+    refreshProviderCache,
+    validateNotAllProvider,
+    validateProvider,
+    validateStacQuery,
+    wrapErrorHandler(searchHandler)
+  )
+  .post(
+    refreshProviderCache,
+    validateNotAllProvider,
+    validateProvider,
+    validateStacQuery,
+    wrapErrorHandler(searchHandler)
+  );
 
 router
   .route("/:providerId/collections")

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -17,8 +17,8 @@ import {
   refreshProviderCache,
   validateCollection,
   validateProvider,
-  validateCatalogForSearch,
   validateStacQuery,
+  validateNotAllProvider,
 } from "../middleware";
 
 const router = express.Router();
@@ -44,8 +44,8 @@ router.get(
 
 router
   .route("/:providerId/search")
-  .get(refreshProviderCache, validateCatalogForSearch, validateProvider, validateStacQuery, wrapErrorHandler(searchHandler))
-  .post(refreshProviderCache, validateCatalogForSearch, validateProvider, validateStacQuery, wrapErrorHandler(searchHandler));
+  .get(refreshProviderCache, validateNotAllProvider, validateProvider, validateStacQuery, wrapErrorHandler(searchHandler))
+  .post(refreshProviderCache, validateNotAllProvider, validateProvider, validateStacQuery, wrapErrorHandler(searchHandler));
 
 router
   .route("/:providerId/collections")
@@ -65,6 +65,7 @@ router
 router.get(
   "/:providerId/collections/:collectionId",
   refreshProviderCache,
+  validateNotAllProvider,
   validateProvider,
   validateStacQuery,
   validateCollection,
@@ -74,6 +75,7 @@ router.get(
 router.get(
   "/:providerId/collections/:collectionId/items",
   refreshProviderCache,
+  validateNotAllProvider,
   validateProvider,
   validateStacQuery,
   validateCollection,
@@ -83,6 +85,7 @@ router.get(
 router.get(
   "/:providerId/collections/:collectionId/items/:itemId",
   refreshProviderCache,
+  validateNotAllProvider,
   validateProvider,
   validateStacQuery,
   validateCollection,

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -17,6 +17,7 @@ import {
   refreshProviderCache,
   validateCollection,
   validateProvider,
+  validateCatalogForSearch,
   validateStacQuery,
 } from "../middleware";
 
@@ -43,8 +44,8 @@ router.get(
 
 router
   .route("/:providerId/search")
-  .get(refreshProviderCache, validateProvider, validateStacQuery, wrapErrorHandler(searchHandler))
-  .post(refreshProviderCache, validateProvider, validateStacQuery, wrapErrorHandler(searchHandler));
+  .get(refreshProviderCache, validateCatalogForSearch, validateProvider, validateStacQuery, wrapErrorHandler(searchHandler))
+  .post(refreshProviderCache, validateCatalogForSearch, validateProvider, validateStacQuery, wrapErrorHandler(searchHandler));
 
 router
   .route("/:providerId/collections")

--- a/src/utils/testUtils.ts
+++ b/src/utils/testUtils.ts
@@ -14,6 +14,10 @@ export const generateSTACCollections = (quantity: number) => {
         type: "Collection",
         description: faker.hacker.phrase(),
         license: "proprietary",
+        providers: [{
+          name: "PROV1",
+          roles: ["producer"]
+        }],
         extent: {
           spatial: {
             bbox: [

--- a/src/utils/testUtils.ts
+++ b/src/utils/testUtils.ts
@@ -14,10 +14,12 @@ export const generateSTACCollections = (quantity: number) => {
         type: "Collection",
         description: faker.hacker.phrase(),
         license: "proprietary",
-        providers: [{
-          name: "PROV1",
-          roles: ["producer"]
-        }],
+        providers: [
+          {
+            name: "PROV1",
+            roles: ["producer"],
+          },
+        ],
         extent: {
           spatial: {
             bbox: [


### PR DESCRIPTION
# Overview

### What is the feature?

Allows users to perform collection searches across all providers.

### What is the Solution?

Add the virtual catalog 'ALL' which will return collection inventories without a provider clause in the collection query

### What areas of the application does this impact?

- /stac - adds the 'all' child
- /stac/ALL - returns collections across all providers using each collection's provider to formulate rel=child links.
- /stac/ALL/collections - returns detailed collections across all providers using each collection's provider to formulate 
- rel=item links.
- /stac/ALL/search - disallowed

# Testing

### Reproduction steps

- **SIT**
- **Any collection**

1. Navigate to cmr.sit.earthdata.nasa.gov/stac
2. Observe child link 
`{
            "rel": "child",
            "title": "all",
            "type": "application/json",
            "href": "https://cmr.sit.earthdata.nasa.gov/stac/ALL"
        }`
3. Navigate to cmr.sit.earthdata.nasa.gov/stac/ALL
4. Observe absence of rel=search links
5. Observe standard rel=child links for each collection but note that the route to those collections is via their provider and not 'all'
`{
            "rel": "child",
            "href": "https://cmr.sit.earthdata.nasa.gov/stac/AMD_KOPRI/collections/Test%201_1.2",
            "title": "\"The Omnivores Dilemma\": The Effect of Autumn Diet on Winter Physiology and Condition of Juvenile Antarctic Krill",
            "type": "application/json"
        },`
6. Navigate to cmr.sit.earthdata.nasa.gov/stac/ALL/collections
7. Observe, for each collection, the presence of a rel=items link that refers to the collection provider rather than 'all'. For example:
`{
                    "rel": "items",
                    "href": "https://cmr.sit.earthdata.nasa.gov/stac/AMD_KOPRI/collections/Test%201_1.2/items",
                    "type": "application/geo+json",
                    "title": "Collection Items"
                }`
8. Navigate to cmr.sit.earthdata.nasa.gov/stac/ALL/collections/Test%201_1.2
9. Observe a 404 error
10. Navigate to cmr.sit.earthdata.nasa.gov/stac/ALL/search
11. Observe a 404 error
12. Navigate to cmr.sit.earthdata.nasa.gov/stac/ALL/collections/Test%201_1.2/items
13. Observe a 404 error
14. Navigate to cmr.sit.earthdata.nasa.gov/stac/ALL/collections?q=amazonia&limit=12
15. Observe collection with ID: AMZ1-WFI-L4-SR-1_NA
16. Observe link within that collection of rel=items with href=https://data.inpe.br/bdc/stac/v1/collections/AMZ1-WFI-L4-SR-1/items

### Attachments

Radian Earth integrations:
![image](https://github.com/user-attachments/assets/2887118a-2b52-45a3-b235-035f30e72cdf)
![image](https://github.com/user-attachments/assets/a3618c1b-e58b-4cc7-a9fd-3236b3bc5d19)


# Checklist

- [X] I have added automated tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings

