### PR TITLE
CMR-10564: Change 'ALL' provider title to all caps

### DIFF
--- a/src/__tests__/rootCatalog.spec.ts
+++ b/src/__tests__/rootCatalog.spec.ts
@@ -100,14 +100,14 @@ describe("GET /stac", () => {
       expect(statusCode).to.equal(200);
       const [, expectedProviders] = cmrProvidersResponse;
 
-      const allLink = body.links.find((l: Link) => l.title === "ALL");
+      const allLink = body.links.find((l: Link) => l.title === "all");
 
       expect(allLink.href).to.match(/^(http)s?:\/\/.*\w+/);
       expect(allLink.href).to.endWith("/stac/ALL");
       expect(allLink.href).to.not.contain("?param=value");
       expect(allLink.rel).to.equal("child");
       expect(allLink.type).to.equal("application/json");
-      expect(allLink.title).to.equal("ALL");
+      expect(allLink.title).to.equal("all");
     });
   });
 

--- a/src/__tests__/rootCatalog.spec.ts
+++ b/src/__tests__/rootCatalog.spec.ts
@@ -100,14 +100,14 @@ describe("GET /stac", () => {
       expect(statusCode).to.equal(200);
       const [, expectedProviders] = cmrProvidersResponse;
 
-      const allLink = body.links.find((l: Link) => l.title === "all");
+      const allLink = body.links.find((l: Link) => l.title === "ALL");
 
       expect(allLink.href).to.match(/^(http)s?:\/\/.*\w+/);
       expect(allLink.href).to.endWith("/stac/ALL");
       expect(allLink.href).to.not.contain("?param=value");
       expect(allLink.rel).to.equal("child");
       expect(allLink.type).to.equal("application/json");
-      expect(allLink.title).to.equal("all");
+      expect(allLink.title).to.equal("ALL");
     });
   });
 

--- a/src/domains/providers.ts
+++ b/src/domains/providers.ts
@@ -10,8 +10,8 @@ const CMR_LB_SEARCH_COLLECTIONS = `${CMR_LB_SEARCH}/collections`;
 
 export const ALL_PROVIDER = "ALL";
 export const ALL_PROVIDERS = {
-  "provider-id": ALL_PROVIDER.toUpperCase(),
-  "short-name": ALL_PROVIDER.toLowerCase(),
+  "provider-id": ALL_PROVIDER,
+  "short-name": ALL_PROVIDER,
 };
 
 export const conformance = [


### PR DESCRIPTION
# Overview

### What is the feature?
'ALL' provider title is in all caps

### What is the Solution?

Removed .toLowerCase() from ALL_PROVIDER in src/domains/providers.ts

### What areas of the application does this impact?

/stac

# Testing

### Reproduction steps

- **Environment for testing:**
- **Collection to test with:**

1. Run CMR stac locally.
2. Navigate to the root catalog
3. Look for the all provider and verify that the title is uppercase.

### Attachments
<img width="1470" alt="Screenshot 2025-06-04 at 2 53 25 PM" src="https://github.com/user-attachments/assets/900551e9-57a5-4dc0-965b-e6cb63411267" />

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

