### PR TITLE
CMR-10563: remove item conformance classes for ALL provider

### DIFF
--- a/src/__tests__/providerCatalog.spec.ts
+++ b/src/__tests__/providerCatalog.spec.ts
@@ -352,6 +352,34 @@ describe("GET /:provider", () => {
       expect(children).to.have.length(0);
       expect(statusCode).to.equal(200);
     });
+    it("should have collection search conformance classes", async() => {
+      sandbox
+        .stub(Provider, "getProviders")
+        .resolves([null, [{ "provider-id": "TEST", "short-name": "TEST" }]]);
+
+      sandbox.stub(Collections, "getCollectionIds").resolves({ count: 0, cursor: null, items: [] });
+
+      const { body: catalog, statusCode } = await request(stacApp).get("/stac/ALL");
+
+      expect(statusCode).to.equal(200);
+      const conformanceClasses = catalog.conformsTo;
+      const collectionSearchClasses = conformanceClasses.filter((c: String) => c.includes("collection-search"));
+      expect(collectionSearchClasses).not.to.be.empty;
+    })
+    it("should not have any item search conformance classes", async() => {
+      sandbox
+        .stub(Provider, "getProviders")
+        .resolves([null, [{ "provider-id": "TEST", "short-name": "TEST" }]]);
+
+      sandbox.stub(Collections, "getCollectionIds").resolves({ count: 0, cursor: null, items: [] });
+
+      const { body: catalog, statusCode } = await request(stacApp).get("/stac/ALL");
+
+      expect(statusCode).to.equal(200);
+      const conformanceClasses = catalog.conformsTo;
+      const itemSearchClasses = conformanceClasses.filter((c: String) => c.includes("item-search"));
+      expect(itemSearchClasses).to.be.empty;
+    })
     it("should be able to handle providers whose name contains the text 'ALL'", async () => {
       sandbox
         .stub(Provider, "getProviders")

--- a/src/__tests__/providerConformance.spec.ts
+++ b/src/__tests__/providerConformance.spec.ts
@@ -26,6 +26,12 @@ describe("GET /:provider/conformance", () => {
             expect(body.conformsTo).to.deep.equal(conformance);
         })
     })
+    describe("given an invalid provider", () => {
+        it("should return a 404 status", async () => {
+            const res = await request(stacApp).get("/stac/PROVIDER_NOT_FOUND/conformance");
+            expect(res.statusCode).to.equal(404);
+        })
+    })
     describe("given the ALL provider/catalog", () => {
         it("should have collection search conformance classes", async () => {
             const { body, statusCode } = await request(stacApp).get("/stac/ALL/conformance");

--- a/src/__tests__/providerConformance.spec.ts
+++ b/src/__tests__/providerConformance.spec.ts
@@ -1,0 +1,45 @@
+import * as sinon from "sinon";
+import { expect } from "chai";
+import request from "supertest";
+
+import { createApp } from "../app";
+import * as Provider from "../domains/providers";
+import { conformance } from "../domains/providers";
+
+const stacApp = createApp();
+const sandbox = sinon.createSandbox();
+
+describe("GET /:provider/conformance", () => {
+    beforeEach(() => {
+      sandbox
+        .stub(Provider, "getProviders")
+        .resolves([null, [{ "provider-id": "TEST", "short-name": "TEST" }]]);
+    });
+    afterEach(() => {
+        sandbox.restore();
+    })
+
+    describe("given a valid provider", () => {
+        it("should return the correct conformance classes", async () => {
+            const { body, statusCode } = await request(stacApp).get("/stac/TEST/conformance");
+            expect(statusCode).to.equal(200);
+            expect(body.conformsTo).to.deep.equal(conformance);
+        })
+    })
+    describe("given the ALL provider/catalog", () => {
+        it("should have collection search conformance classes", async () => {
+            const { body, statusCode } = await request(stacApp).get("/stac/ALL/conformance");
+            expect(statusCode).to.equal(200);
+            const conformanceClasses = body.conformsTo;
+            const collectionSearchClasses = conformanceClasses.filter((c: String) => c.includes("collection-search"));
+            expect(collectionSearchClasses).not.to.be.empty;
+        })
+        it("should not contain item search conformance classes", async () => {
+            const { body, statusCode } = await request(stacApp).get("/stac/ALL/conformance");
+            expect(statusCode).to.equal(200);
+            const conformanceClasses = body.conformsTo;
+            const itemSearchClasses = conformanceClasses.filter((c: String) => c.includes("item-search"));
+            expect(itemSearchClasses).to.be.empty;
+        })
+    })
+})

--- a/src/domains/providers.ts
+++ b/src/domains/providers.ts
@@ -32,6 +32,18 @@ export const conformance = [
   "http://www.opengis.net/spec/ogcapi-common-1/1.0/conf/simple-query",
 ];
 
+export const conformanceAll = [
+  "https://api.stacspec.org/v1.0.0-rc.2/core",
+  "https://api.stacspec.org/v1.0.0-rc.2/ogcapi-features",
+  "http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/core",
+  "http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/oas30",
+  "http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/geojson",
+  "https://api.stacspec.org/v1.0.0-rc.2/collection-search",
+  "https://api.stacspec.org/v1.0.0-rc.2/collection-search#free-text",
+  "https://api.stacspec.org/v1.0.0-rc.2/collection-search#sort",
+  "http://www.opengis.net/spec/ogcapi-common-1/1.0/conf/simple-query",
+]
+
 /**
  * Return an array of providers found in CMR.
  */

--- a/src/routes/catalog.ts
+++ b/src/routes/catalog.ts
@@ -4,7 +4,7 @@ import { stringify as stringifyQuery } from "qs";
 import { Links, STACCatalog } from "../@types/StacCatalog";
 
 import { getAllCollectionIds } from "../domains/collections";
-import { conformance } from "../domains/providers";
+import { conformance, conformanceAll } from "../domains/providers";
 import { ServiceUnavailableError } from "../models/errors";
 import { getBaseUrl, mergeMaybe, stacContext } from "../utils";
 import { CMR_QUERY_MAX } from "../domains/stac";
@@ -157,7 +157,7 @@ export const providerCatalogHandler = async (req: Request, res: Response) => {
     title: `${provider["provider-id"]} STAC Catalog`,
     stac_version: STAC_VERSION,
     description: `Root STAC catalog for ${provider["provider-id"]}`,
-    conformsTo: conformance,
+    conformsTo: provider["provider-id"] === ALL_PROVIDER ? conformanceAll : conformance,
     links: [...selfLinks, ...childLinks],
   } as STACCatalog;
 

--- a/src/routes/providerConformance.ts
+++ b/src/routes/providerConformance.ts
@@ -1,9 +1,9 @@
 import { Request, Response } from "express";
 import { ALL_PROVIDER, conformance, conformanceAll } from "../domains/providers";
 
-export const providerConformanceHandler = async (_req: Request, res: Response): Promise<void> => {
+export const providerConformanceHandler = async (req: Request, res: Response): Promise<void> => {
   const {
     params: { providerId: provider },
-  } = _req;
+  } = req;
   res.json({ conformsTo: provider === ALL_PROVIDER ? conformanceAll : conformance });
 };

--- a/src/routes/providerConformance.ts
+++ b/src/routes/providerConformance.ts
@@ -1,6 +1,9 @@
 import { Request, Response } from "express";
-import { conformance } from "../domains/providers";
+import { ALL_PROVIDER, conformance, conformanceAll } from "../domains/providers";
 
 export const providerConformanceHandler = async (_req: Request, res: Response): Promise<void> => {
-  res.json({ conformsTo: conformance });
+  const {
+    params: { providerId: provider },
+  } = _req;
+  res.json({ conformsTo: provider === ALL_PROVIDER ? conformanceAll : conformance });
 };


### PR DESCRIPTION
# Overview

### What is the feature?

The ALL provider contained conformance classes for item (granule) search despite not supporting that functionality.

### What is the Solution?

Removed item search conformance classes from the ALL provider catalog page (/stac/ALL) and the conformance page (/stac/ALL/conformance).

### What areas of the application does this impact?

- /stac/ALL
- /stac/ALL/conformance

# Testing

### Reproduction steps

- **Environment for testing:**
- **Collection to test with:**

1. Run CMR-STAC locally and navigate to /stac/ALL and /stac/ALL/conformance
2. Make sure that "conformsTo" does not contain any conformance classes with "item-search":

- "https://api.stacspec.org/v1.0.0-rc.2/item-search#fields",
- "https://api.stacspec.org/v1.0.0-rc.2/item-search#features",
- "https://api.stacspec.org/v1.0.0-rc.2/item-search#query",
- "https://api.stacspec.org/v1.0.0-rc.2/item-search#sort",
- "https://api.stacspec.org/v1.0.0-rc.2/item-search#context"

### Attachments
![image](https://github.com/user-attachments/assets/dfde09b2-d40a-43d2-b922-018df5ee49bf)
![image](https://github.com/user-attachments/assets/c87f9eed-d819-4957-bc82-f3452e48d840)

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

