### PR TITLE
CMR-10617: Append collection search constraints to rel=items links

### DIFF
--- a/src/routes/__tests__/browse.spec.ts
+++ b/src/routes/__tests__/browse.spec.ts
@@ -13,6 +13,7 @@ import {
   collectionHandler,
   collectionsHandler,
   addItemLinkIfNotPresent,
+  addQueryParametersToItemLink,
   generateBaseUrlForCollection,
   generateCollectionResponse,
 } from "../browse";
@@ -20,10 +21,6 @@ import { generateSTACCollections } from "../../utils/testUtils";
 
 describe("addItemLinkIfNotPresent", () => {
   it("will add an item link if no item link is present", async () => {
-    const mockRequest = {
-      method: "GET",
-      originalUrl: "/stac/TEST_PROV/collections",
-    } as Request;
     // Create a STACCollection with no item link
     let stacCollection = generateSTACCollections(1)[0];
     // Add a non-item link
@@ -36,7 +33,7 @@ describe("addItemLinkIfNotPresent", () => {
 
     const numberoOfLinks = stacCollection.links.length;
     // Invoke method
-    addItemLinkIfNotPresent(stacCollection, "https://foo.com", mockRequest);
+    addItemLinkIfNotPresent(stacCollection, "https://foo.com");
     // Observe an addiitonal link in the STAC Collection with rel=items etc.
     expect(stacCollection.links.length).to.equal(numberoOfLinks + 1);
     expect(stacCollection).to.have.deep.property("links", [
@@ -55,11 +52,6 @@ describe("addItemLinkIfNotPresent", () => {
     ]);
   });
   it("will not add an item link if an item link is present", async () => {
-    const mockRequest = {
-      method: "GET",
-      originalUrl: "/stac/TEST_PROV/collections",
-    } as Request;
-
     // Create a STACCollection with no item link
     let stacCollection = generateSTACCollections(1)[0];
 
@@ -79,7 +71,7 @@ describe("addItemLinkIfNotPresent", () => {
     });
     const numberoOfLinks = stacCollection.links.length;
     // Invoke method
-    addItemLinkIfNotPresent(stacCollection, "https://foo.com/items", mockRequest);
+    addItemLinkIfNotPresent(stacCollection, "https://foo.com/items");
     // Observe no addiitonal link in the STAC Collection and that the item link remains a CMR link
     expect(stacCollection.links.length).to.equal(numberoOfLinks);
     expect(stacCollection).to.have.deep.property("links", [
@@ -94,46 +86,6 @@ describe("addItemLinkIfNotPresent", () => {
         href: "https://example.com/foo",
         type: "application/html",
         title: "foo",
-      },
-    ]);
-  });
-  it("will append collection search query parameters, with no item link present", async () => {
-    const mockRequest = {
-      method: "GET",
-      originalUrl:
-        "/stac/TEST_PROV/collections?bbox=0,-90,180,90&datetime=2001-01-01T00:00:00.000Z,2001-12-01T00:00:00.000Z",
-    } as Request;
-    let stacCollection = generateSTACCollections(1)[0];
-    addItemLinkIfNotPresent(stacCollection, "https://foo.com", mockRequest);
-    expect(stacCollection).to.have.deep.property("links", [
-      {
-        rel: "items",
-        href: "https://foo.com/items?bbox=0,-90,180,90&datetime=2001-01-01T00:00:00.000Z,2001-12-01T00:00:00.000Z",
-        type: "application/geo+json",
-        title: "Collection Items",
-      },
-    ]);
-  });
-  it("will append collection search query parameters, with an item link present", async () => {
-    const mockRequest = {
-      method: "GET",
-      originalUrl:
-        "/stac/TEST_PROV/collections?bbox=0,-90,180,90&datetime=2001-01-01T00:00:00.000Z,2001-12-01T00:00:00.000Z",
-    } as Request;
-    let stacCollection = generateSTACCollections(1)[0];
-    stacCollection.links.push({
-      rel: "items",
-      href: "https://example.com/items",
-      type: "application/geo+json",
-      title: "Collection Items",
-    });
-    addItemLinkIfNotPresent(stacCollection, "https://foo.com/items", mockRequest);
-    expect(stacCollection).to.have.deep.property("links", [
-      {
-        rel: "items",
-        href: "https://example.com/items?bbox=0,-90,180,90&datetime=2001-01-01T00:00:00.000Z,2001-12-01T00:00:00.000Z",
-        type: "application/geo+json",
-        title: "Collection Items",
       },
     ]);
   });
@@ -172,5 +124,31 @@ describe("generateCollectionResponse", () => {
     const baseUrl = "http://localhost:3000/stac/PROV1/collections";
     const collectionsResponse = generateCollectionResponse(baseUrl, [], stacCollections);
     expect(collectionsResponse.description).to.equal("All collections provided by PROV1");
+  });
+});
+
+describe("addQueryParametersToItemLink", () => {
+  it("will append collection search query parameters", async () => {
+    const mockRequest = {
+      method: "GET",
+      originalUrl:
+        "/stac/TEST_PROV/collections?bbox=0,-90,180,90&datetime=2001-01-01T00:00:00.000Z,2001-12-01T00:00:00.000Z",
+    } as Request;
+    let stacCollection = generateSTACCollections(1)[0];
+    stacCollection.links.push({
+      rel: "items",
+      href: "https://example.com/items",
+      type: "application/geo+json",
+      title: "Collection Items",
+    });
+    addQueryParametersToItemLink(stacCollection, mockRequest);
+    expect(stacCollection).to.have.deep.property("links", [
+      {
+        rel: "items",
+        href: "https://example.com/items?bbox=0,-90,180,90&datetime=2001-01-01T00:00:00.000Z,2001-12-01T00:00:00.000Z",
+        type: "application/geo+json",
+        title: "Collection Items",
+      },
+    ]);
   });
 });


### PR DESCRIPTION
# Overview

### What is the feature?

When a user searches a collection with query parameters, those constraints are not carried over to the rel=items search links.

### What is the Solution?

Append the query parameters of the original URL of a collection search to the rel=items links of each collection.

### What areas of the application does this impact?

/stac/:providerId/collections

# Testing

### Reproduction steps

- **Environment for testing:**
- **Collection to test with:**

1. Run CMR-STAC locally.
2. Perform a collection search with query parameters (e.g. http://localhost:3000/stac/ALL/collections?datetime=2001-01-01T00:00:00.000Z,2001-12-01T00:00:00.000Z)
3. Verify that the rel=items link for each collection includes the correct appended parameters

### Attachments

![image](https://github.com/user-attachments/assets/d4fc979d-8628-4669-a54f-7092bed24b45)

# Checklist

- [x] I have added automated tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings

