### PR TITLE
CMR-10557 'ALL' provider should be visible in cloudstac

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -22,6 +22,8 @@ by CMR-STAC with [`nvm`](https://github.com/nvm-sh/nvm) (recommended for managin
 
 - install aws-sam-cli (`brew install aws-sam-cli`)
 
+- install Docker(`brew install docker`)
+
 ```bash
 nvm use
 ```
@@ -44,7 +46,7 @@ To lint your developed code:
 npm run prettier:fix
 ```
 
-To run the CMR-STAC server locally:
+To run locally, with Docker running and aws-sam-cli installed, run
 
 ```bash
 npm run start

--- a/src/__tests__/providerConformance.spec.ts
+++ b/src/__tests__/providerConformance.spec.ts
@@ -34,7 +34,7 @@ describe("GET /:provider/conformance", () => {
       expect(res.statusCode).to.equal(404);
     });
   });
-  describe("given the ALL provider/catalog", () => {
+  describe("given the /stac/ALL provider/catalog", () => {
     it("should have collection search conformance classes", async () => {
       const { body, statusCode } = await request(stacApp).get("/stac/ALL/conformance");
       const conformanceClasses = body.conformsTo;
@@ -47,6 +47,32 @@ describe("GET /:provider/conformance", () => {
     });
     it("should not contain item search conformance classes", async () => {
       const { body, statusCode } = await request(stacApp).get("/stac/ALL/conformance");
+      const conformanceClasses = body.conformsTo;
+      const itemSearchClasses = conformanceClasses.filter((c: String) => c.includes("item-search"));
+
+      expect(statusCode).to.equal(200);
+      expect(itemSearchClasses).to.be.empty;
+    });
+  });
+
+  describe("given the /cloudstac/ALL provider/catalog", () => {
+    beforeEach(() => {
+      sandbox
+        .stub(Provider, "getCloudProviders")
+        .resolves([null, [{ "short-name": "CLOUD_PROV", "provider-id": "CLOUD_PROV" }]]);
+    });
+    it("should have collection search conformance classes", async () => {
+      const { body, statusCode } = await request(stacApp).get("/cloudstac/ALL/conformance");
+      const conformanceClasses = body.conformsTo;
+      const collectionSearchClasses = conformanceClasses.filter((c: String) =>
+        c.includes("collection-search")
+      );
+
+      expect(statusCode).to.equal(200);
+      expect(collectionSearchClasses).not.to.be.empty;
+    });
+    it("should not contain item search conformance classes", async () => {
+      const { body, statusCode } = await request(stacApp).get("/cloudstac/ALL/conformance");
       const conformanceClasses = body.conformsTo;
       const itemSearchClasses = conformanceClasses.filter((c: String) => c.includes("item-search"));
 

--- a/src/__tests__/providerSearch.spec.ts
+++ b/src/__tests__/providerSearch.spec.ts
@@ -331,7 +331,7 @@ describe("Query validation", () => {
   });
 });
 
-describe("GET /ALL/search", () => {
+describe("GET stac/ALL/search", () => {
   describe("given an 'ALL' provider", () => {
     it("should return a 404", async () => {
       sandbox
@@ -348,7 +348,7 @@ describe("GET /ALL/search", () => {
   });
 });
 
-describe("POST /ALL/search", () => {
+describe("POST stac/ALL/search", () => {
   describe("given an 'ALL' provider", () => {
     it("should return a 404", async () => {
       sandbox
@@ -356,6 +356,45 @@ describe("POST /ALL/search", () => {
         .resolves([null, [{ "provider-id": "TEST", "short-name": "TEST" }]]);
 
       const { statusCode, body } = await request(app).post("/stac/ALL/search");
+
+      expect(statusCode).to.equal(404);
+      expect(body).to.deep.equal({
+        errors: ["This operation is not allowed for the ALL Catalog."],
+      });
+    });
+  });
+});
+
+describe("GET cloudstac/ALL/search", () => {
+  describe("given an 'ALL' provider", () => {
+    it("should return a 404", async () => {
+      sandbox
+        .stub(Providers, "getProviders")
+        .resolves([null, [{ "provider-id": "TEST", "short-name": "TEST" }]]);
+      sandbox
+        .stub(Providers, "getCloudProviders")
+        .resolves([null, [{ "short-name": "CLOUD_PROV", "provider-id": "CLOUD_PROV" }]]);
+      const { statusCode, body } = await request(app).get("/cloudstac/ALL/search");
+
+      expect(statusCode).to.equal(404);
+      expect(body).to.deep.equal({
+        errors: ["This operation is not allowed for the ALL Catalog."],
+      });
+    });
+  });
+});
+
+describe("POST cloudstac/ALL/search", () => {
+  describe("given an 'ALL' provider", () => {
+    it("should return a 404", async () => {
+      sandbox
+        .stub(Providers, "getProviders")
+        .resolves([null, [{ "provider-id": "TEST", "short-name": "TEST" }]]);
+      sandbox
+        .stub(Providers, "getCloudProviders")
+        .resolves([null, [{ "short-name": "CLOUD_PROV", "provider-id": "CLOUD_PROV" }]]);
+
+      const { statusCode, body } = await request(app).post("/cloudstac/ALL/search");
 
       expect(statusCode).to.equal(404);
       expect(body).to.deep.equal({

--- a/src/__tests__/rootCatalog.spec.ts
+++ b/src/__tests__/rootCatalog.spec.ts
@@ -126,7 +126,7 @@ describe("GET /stac", () => {
 describe("/cloudstac", () => {
   let mockCmrHits: (s: string, c: AxiosRequestConfig<any> | undefined) => Promise<any>;
 
-  before(() => {
+  beforeEach(() => {
     sandbox.stub(Providers, "getProviders").resolves([
       null,
       [
@@ -164,5 +164,18 @@ describe("/cloudstac", () => {
     expect(body.links.find((l: { title: string }) => l.title === "NOT_CLOUD")).to.be.undefined;
 
     expect(mockCmrHits).to.have.been.calledThrice;
+  });
+  it("should have an entry for the 'ALL' catalog", async () => {
+    const { statusCode, body } = await request(app).get("/cloudstac");
+
+    expect(statusCode).to.equal(200);
+    const allLink = body.links.find((l: Link) => l.title === "ALL");
+
+    expect(allLink.href).to.match(/^(http)s?:\/\/.*\w+/);
+    expect(allLink.href).to.endWith("/cloudstac/ALL");
+    expect(allLink.href).to.not.contain("?param=value");
+    expect(allLink.rel).to.equal("child");
+    expect(allLink.type).to.equal("application/json");
+    expect(allLink.title).to.equal("ALL");
   });
 });

--- a/src/middleware/index.ts
+++ b/src/middleware/index.ts
@@ -105,7 +105,7 @@ export const refreshProviderCache = async (req: Request, _res: Response, next: N
       const [searchErrs, cloudProvs] = await getCloudProviders(cachedProviders.getAll());
 
       if (searchErrs) return next(new ServiceUnavailableError(ERRORS.serviceUnavailable));
-
+      cloudProvs.push(ALL_PROVIDERS);
       cloudProvs.forEach((cloudProv) =>
         cachedCloudProviders.set(cloudProv["provider-id"], cloudProv)
       );

--- a/src/routes/__tests__/browse.spec.ts
+++ b/src/routes/__tests__/browse.spec.ts
@@ -88,7 +88,7 @@ describe("addItemLinkIfNotPresent", () => {
   });
 });
 
-describe("generateBaseUrlForCollection", () => {
+describe("generateBaseUrlForCollection for stac/ALL", () => {
   it("will use the provider name for an ALL collection result", async () => {
     let stacCollection = generateSTACCollections(1)[0];
 
@@ -109,7 +109,7 @@ describe("generateBaseUrlForCollection", () => {
   });
 });
 
-describe("generateCollectionResponse", () => {
+describe("generateCollectionResponse for stac/ALL", () => {
   it("will add the correct description if the provider is 'ALL'", async () => {
     let stacCollections = generateSTACCollections(1);
     const baseUrl = "http://localhost:3000/stac/ALL/collections";
@@ -119,6 +119,42 @@ describe("generateCollectionResponse", () => {
   it("will add the correct description if the provider is a real provider", async () => {
     let stacCollections = generateSTACCollections(1);
     const baseUrl = "http://localhost:3000/stac/PROV1/collections";
+    const collectionsResponse = generateCollectionResponse(baseUrl, [], stacCollections);
+    expect(collectionsResponse.description).to.equal("All collections provided by PROV1");
+  });
+});
+
+describe("generateBaseUrlForCollection for cloudstac/ALL", () => {
+  it("will use the provider name for an ALL collection result", async () => {
+    let stacCollection = generateSTACCollections(1)[0];
+
+    const baseUrl = generateBaseUrlForCollection(
+      "http://localhost:3000/cloudstac/ALL/collections/Test%201_1.2",
+      stacCollection
+    );
+    expect(baseUrl).to.equal("http://localhost:3000/cloudstac/PROV1/collections/Test%201_1.2");
+  });
+  it("will use the same provider name for any other collection result", async () => {
+    let stacCollection = generateSTACCollections(1)[0];
+
+    const baseUrl = generateBaseUrlForCollection(
+      "http://localhost:3000/cloudstac/PROV1/collections/Test%201_1.2",
+      stacCollection
+    );
+    expect(baseUrl).to.equal("http://localhost:3000/cloudstac/PROV1/collections/Test%201_1.2");
+  });
+});
+
+describe("generateCollectionResponse for cloudstac/ALL", () => {
+  it("will add the correct description if the provider is 'ALL'", async () => {
+    let stacCollections = generateSTACCollections(1);
+    const baseUrl = "http://localhost:3000/cloudstac/ALL/collections";
+    const collectionsResponse = generateCollectionResponse(baseUrl, [], stacCollections);
+    expect(collectionsResponse.description).to.equal("All collections provided by CMR");
+  });
+  it("will add the correct description if the provider is a real provider", async () => {
+    let stacCollections = generateSTACCollections(1);
+    const baseUrl = "http://localhost:3000/cloudstac/PROV1/collections";
     const collectionsResponse = generateCollectionResponse(baseUrl, [], stacCollections);
     expect(collectionsResponse.description).to.equal("All collections provided by PROV1");
   });

--- a/src/routes/browse.ts
+++ b/src/routes/browse.ts
@@ -52,7 +52,13 @@ const collectionLinks = (req: Request, nextCursor?: string | null): Links => {
 export const collectionsHandler = async (req: Request, res: Response): Promise<void> => {
   const { headers } = req;
   req.params.searchType = "collection";
-  const query = await buildQuery(req);
+  const initialQuery = await buildQuery(req);
+
+  const cloudOnly = req.headers["cloud-stac"] === "true" ? { cloudHosted: true } : {};
+  const query = {
+    ...cloudOnly,
+    ...initialQuery,
+  };
 
   // If the query contains a "provider": "ALL" clause, we need to remove it as
   // this is a 'special' provider that means 'all providers'. The absence
@@ -101,7 +107,13 @@ export const collectionHandler = async (req: Request, res: Response): Promise<vo
       `Could not find collection [${collectionId}] in provider [${providerId}]`
     );
   }
+  const cloudOnly = req.headers["cloud-stac"] === "true";
 
+  if (cloudOnly && !collection["storage:schemes"]) {
+    throw new ItemNotFound(
+      `Collection [${collectionId}] may not be cloudhosted. Please try navigating to the equivalent /stac URL.`
+    );
+  };
   collection.links = collection.links
     ? [...collectionLinks(req), ...(collection.links ?? [])]
     : [...collectionLinks(req)];

--- a/src/routes/browse.ts
+++ b/src/routes/browse.ts
@@ -114,7 +114,7 @@ export const collectionHandler = async (req: Request, res: Response): Promise<vo
     throw new ItemNotFound(
       `Collection [${collectionId}] may not be cloudhosted. Please try navigating to the equivalent /stac URL.`
     );
-  };
+  }
   collection.links = collection.links
     ? [...collectionLinks(req), ...(collection.links ?? [])]
     : [...collectionLinks(req)];


### PR DESCRIPTION
# Overview

### What is the feature?
The “ALL” provider is currently not in the cloudstac catalog. Collections, collection, and item do not filter if it is cloud-hosted.

### What is the Solution?
- Add the ALL provider to cloudstac providers
- Add the cloud-hosted parameter to the GraphQL query for /collections endpoints
- If on cloudstac, verify that collections and items are cloud-hosted by checking for the storage extension attribute

### What areas of the application does this impact?
/cloudstac/ALL (add provider)
/cloudstac/:providerId/collections (add cloud-hosted query parameter)
/cloudstac/:providerId/collections/:collectionId (verify cloud-hosted collection)
/cloudstac/:providerId/collections/:collectionId/items (verify cloud-hosted collection)
/cloudstac/:providerId/collections/:collectionId/items/:itemId (verify cloud-hosted item)


# Testing

### Reproduction steps

- **Environment for testing:**
- **Collection to test with:**

1. Run CMR-STAC locally
2. Navigate to /cloudstac and verify that ALL is listed as a provider
3. Navigate to /cloudstac/ALL and verify that the page exists and displays cloud-hosted collections
4. Navigate to a collection/item that is cloud-hosted and verify it is included in cloudstac (e.g. http://localhost:3000/cloudstac/LPCLOUD/collections/HLSS30_2.0/)
5. Navigate to a collection/item that is not cloud-hosted and verify that cloudstac returns an error (e.g. http://localhost:3000/cloudstac/JAXA/collections/ADEOS_OCTS_L3BM_GAC_VI_1day_NA)


### Attachments
<img width="1236" alt="Screenshot 2025-07-09 at 10 07 08 AM" src="https://github.com/user-attachments/assets/db5b166a-24b9-413b-a69a-5b093bafcf86" />
<img width="1285" alt="Screenshot 2025-07-09 at 10 09 48 AM" src="https://github.com/user-attachments/assets/288d28da-5603-46cb-908a-4c00541fc0ee" />
<img width="1299" alt="Screenshot 2025-07-09 at 10 19 00 AM" src="https://github.com/user-attachments/assets/cba80c1b-f63e-49fe-b23c-3e2b456d0ba2" />

# Checklist

- [ x ] I have added automated tests that prove my fix is effective or that my feature works
- [ x ] New and existing unit tests pass locally with my changes
- [ x ] I have performed a self-review of my own code
- [ x ] I have commented my code, particularly in hard-to-understand areas
- [ x ] I have made corresponding changes to the documentation
- [ x ] My changes generate no new warnings

